### PR TITLE
V1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.2
 
 - Fix bug that would occur if Journal entries weren't in a folder of the same name as the adventure.
+- Delay calling `scenePackerReady` hook until after the canvas is ready.
 
 ## v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.2
+
+- Fix bug that would occur if Journal entries weren't in a folder of the same name as the adventure.
+
 ## v1.0.1
 
 - Added localization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## v1.0.2
 
-- Fix bug that would occur if Journal entries weren't in a folder of the same name as the adventure.
+- Fixed bug that would occur if Journal entries weren't in a folder of the same name as the adventure.
 - Delay calling `scenePackerReady` hook until after the canvas is ready.
+- Added `await window['scene-packer'].relinkJournalEntries('module-name');` static method
+    - Automatically goes through the Journals in the module's compendium packs and updates the references from the World version to the Compendium versions.
 
 ## v1.0.1
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -101,6 +101,25 @@
         "details": "You must pass an array of strings to \"SetJournalPacks()\". They must be the names of Journal Packs. Received: {pack}",
         "missing": "SetJournalPacks() called with no value. This disables importing of Journals."
       }
+    },
+    "world-conversion": {
+      "compendiums": {
+        "unlock": "Unlocking compendiums: {list}",
+        "lock": "Locking compendiums: {list}",
+        "checking-and-updating": "Checking and updating {count} journal references from world links to compendium links.",
+        "invalid-ref-type": "Found a journal reference that isn't handled: {type}. Skipping reference...",
+        "invalid-no-name": "Found a journal reference but couldn't find its original name. Check console for details.",
+        "invalid-no-matching-name": "Could not find reference name in world data",
+        "invalid-not-found": "Found a journal reference but couldn't find its compendium version by name. Check console for details.",
+        "invalid-not-found-console": "Could not find reference in compendium data. Skipping updating reference...",
+        "invalid-too-many": "Found a journal reference but found more than one compendium version by name. Check console for details.",
+        "invalid-too-many-console": "Found more than one reference in compendium data. Skipping updating reference...",
+        "updating-journal-references": "Changing {count} journal references in: {journal}",
+        "updating-reference-console": "Changing {pack}[{journalEntryId}] {type} reference {oldRef} -> {newRefPack}.{newRef}",
+        "updating-reference": "Updating {count} references in {journal}. See console for full details.",
+        "completed-journal": "Completed journal {journal} {entryId}",
+        "completed": "Completed!"
+      }
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "library": "true",
   "manifestPlusVersion": "1.0.0",
   "minimumCoreVersion": "0.7.9",
@@ -27,7 +27,7 @@
   }],
   "url": "https://github.com/League-of-Foundry-Developers/scene-packer",
   "manifest": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/latest/download/module.json",
-  "download": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/download/1.0.1/module.zip",
+  "download": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/download/1.0.2/module.zip",
   "bugs": "https://github.com/League-of-Foundry-Developers/scene-packer/issues",
   "changelog": "https://github.com/League-of-Foundry-Developers/scene-packer/blob/master/changelog.md",
   "allowBugReporter": true

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -1014,4 +1014,6 @@ window['scene-packer'] = {
   getInstance: ScenePacker.GetInstance,
 };
 
-Hooks.callAll('scenePackerReady', window['scene-packer']);
+Hooks.on('canvasReady', () => {
+  Hooks.callAll('scenePackerReady', window['scene-packer']);
+});

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -723,7 +723,7 @@ export default class ScenePacker {
       .filter((info) => {
         // Filter for only the entries that are missing, or are in a different folder.
         const j = game.journal.getName(info.journalName);
-        return j == null || j.data.folder !== folder.id;
+        return j == null || (folder && j.data.folder !== folder.id);
       })
       .map((info) => info.journalName);
     return missing_journals;


### PR DESCRIPTION
- Fixed bug that would occur if Journal entries weren't in a folder of the same name as the adventure.
- Delay calling `scenePackerReady` hook until after the canvas is ready.
- Added `await window['scene-packer'].relinkJournalEntries('module-name');` static method
    - Automatically goes through the Journals in the module's compendium packs and updates the references from the World version to the Compendium versions.