### PR TITLE
Support default permissions on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.2
+
+- Entity Default Permissions
+  - Entities exported to compendiums with a default permission of something other than "None" will now import back again with that default permission.
+  - This only applies to compendiums that are owned by a module registered with Scene Packer.
+
 ## v2.2.1
 
 - Added compatibility with Foundry VTT v0.8.3

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/wrapped.js
+++ b/scripts/wrapped.js
@@ -4,13 +4,15 @@ import {libWrapper} from './shim.js';
  * Utilise libWrapper to ensure we get a sourceId for each of our compendium imports
  */
 Hooks.once('setup', function () {
-    // Only need to patch the sourceId in versions < 0.8.0
     if (!isNewerVersion(game.data.version, '0.7.9')) {
       libWrapper.register(
         'scene-packer',
         'Entity.prototype.toCompendium',
         async function (wrapped, ...args) {
           await this.setFlag(ScenePacker.MODULE_NAME, 'sourceId', this.uuid);
+          if (this.data?.permission?.default) {
+            await this.setFlag(ScenePacker.MODULE_NAME, ScenePacker.FLAGS_DEFAULT_PERMISSION, this.data.permission.default);
+          }
 
           return wrapped.bind(this)(...args);
         },
@@ -95,6 +97,9 @@ Hooks.once('setup', function () {
           async function (wrapped, ...args) {
             // const [ pack ] = args;
             await this.setFlag(ScenePacker.MODULE_NAME, 'sourceId', this.uuid);
+            if (this.data?.permission?.default) {
+              await this.setFlag(ScenePacker.MODULE_NAME, ScenePacker.FLAGS_DEFAULT_PERMISSION, this.data.permission.default);
+            }
 
             return wrapped.bind(this)(...args);
           },


### PR DESCRIPTION
- Entity Default Permissions
  - Entities exported to compendiums with a default permission of something other than "None" will now import back again with that default permission.
  - This only applies to compendiums that are owned by a module registered with Scene Packer.