### PR TITLE
Fix error when Quick Encounters is not installed on the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.4
+
+- Fixed error when Quick Encounters module was not installed on the server, rather than just not enabled.
+
 ## v2.2.3
 
 - Added compatibility with Foundry VTT v0.8.4

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2871,6 +2871,17 @@ export default class ScenePacker {
       return;
     }
 
+    // Check if the quick encounters module exists at all and bail if it isn't.
+    let scopes = [];
+    if (isNewerVersion('0.8.0', game.data.version)) {
+      scopes = game.getPackageScopes();
+    } else {
+      scopes = SetupConfiguration.getPackageScopes();
+    }
+    if (!scopes.length || !scopes.includes(scope)) {
+      return;
+    }
+
     let quickEncounter = {};
     const quickEncounterData = journal.getFlag('quick-encounters', 'quickEncounter');
     if (quickEncounterData) {


### PR DESCRIPTION
Was fine when the module is installed but not enabled. But would break due to the flag scope if it wasn't installed at all.