### PR TITLE
v2.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.14
+
+- Scene thumbnails generate are now generated for tile only Scenes
+  - Core v0.7.x normally require a Scene Background to generate a thumbnail.
+- Added additional spacing to the Instance Prompt dialog.
+- Downgraded several Errors to Warnings.
+
 ## v2.2.13
 
 - Compatibility with Core v0.8.6

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -1146,7 +1146,7 @@ export default class ScenePacker {
     }
 
     if (!possibleMatches.length) {
-      ui.notifications.error(
+      ui.notifications.warn(
         game.i18n.format(
           'SCENE-PACKER.notifications.find-actor-compendium.no-match',
           {
@@ -1154,7 +1154,7 @@ export default class ScenePacker {
           },
         ),
       );
-      this.logError(
+      this.logWarn(
         true,
         game.i18n.format(
           'SCENE-PACKER.notifications.find-actor-compendium.no-match',
@@ -1183,7 +1183,7 @@ export default class ScenePacker {
     }
 
     if (!compendiumActor) {
-      ui.notifications.error(
+      ui.notifications.warn(
         game.i18n.format(
           'SCENE-PACKER.notifications.find-actor-compendium.no-match',
           {
@@ -1191,7 +1191,7 @@ export default class ScenePacker {
           },
         ),
       );
-      this.logError(
+      this.logWarn(
         true,
         game.i18n.format(
           'SCENE-PACKER.notifications.find-actor-compendium.no-match',
@@ -1264,7 +1264,7 @@ export default class ScenePacker {
     }
 
     if (!possibleMatches.length) {
-      ui.notifications.error(
+      ui.notifications.warn(
         game.i18n.format(
           'SCENE-PACKER.notifications.find-playlist-compendium.no-match',
           {
@@ -1272,7 +1272,7 @@ export default class ScenePacker {
           },
         ),
       );
-      this.logError(
+      this.logWarn(
         true,
         game.i18n.format(
           'SCENE-PACKER.notifications.find-playlist-compendium.no-match',
@@ -1307,7 +1307,7 @@ export default class ScenePacker {
     }
 
     if (!compendiumPlaylist) {
-      ui.notifications.error(
+      ui.notifications.warn(
         game.i18n.format(
           'SCENE-PACKER.notifications.find-playlist-compendium.no-match',
           {
@@ -1315,7 +1315,7 @@ export default class ScenePacker {
           },
         ),
       );
-      this.logError(
+      this.logWarn(
         true,
         game.i18n.format(
           'SCENE-PACKER.notifications.find-playlist-compendium.no-match',
@@ -1982,7 +1982,7 @@ export default class ScenePacker {
     });
 
     if (missing.length > 0) {
-      this.logError(
+      this.logWarn(
         true,
         game.i18n.format('SCENE-PACKER.notifications.link-tokens.missing', {
           count: missing.length,
@@ -2092,12 +2092,7 @@ export default class ScenePacker {
 
     const missing = updates.filter((info) => !info.entryId);
     if (missing.length > 0) {
-      ui.notifications.error(
-        game.i18n.format('SCENE-PACKER.notifications.spawn-notes.missing', {
-          count: missing.length,
-        }),
-      );
-      this.logError(
+      this.logWarn(
         true,
         game.i18n.format(
           'SCENE-PACKER.notifications.spawn-notes.missing-details',
@@ -3123,6 +3118,7 @@ export default class ScenePacker {
     content += '</select>';
     content += `<p><label>${game.i18n.localize('SCENE-PACKER.relink-prompt.make-changes')} <input type="checkbox" id="make-changes"></label></p>`;
     content += `<p>${game.i18n.localize('SCENE-PACKER.relink-prompt.make-changes-info')}</p>`;
+    content += '<p><hr></p>';
     let d = new Dialog({
       title: game.i18n.localize('SCENE-PACKER.relink-prompt.title'),
       content: content,
@@ -3179,6 +3175,7 @@ export default class ScenePacker {
         content += `<option value="${m}">${m}</option>`;
       });
       content += '</select>';
+      content += '<p><hr></p>';
       let d = new Dialog({
         title: game.i18n.localize('SCENE-PACKER.instance-prompt.title'),
         content: content,
@@ -3275,7 +3272,7 @@ Hooks.once('setup', () => {
                 game.user.isGM &&
                 game.settings.get(MODULE_NAME, 'enableContextMenu');
             }
-            return false;
+            return game.user.isGM && game.settings.get(MODULE_NAME, 'enableContextMenu');
           },
           callback: (li) => {
             let scene = game.scenes.get(li.data('entityId'));

--- a/scripts/wrapped.js
+++ b/scripts/wrapped.js
@@ -27,6 +27,21 @@ Hooks.once('setup', function () {
 
       libWrapper.register(
         'scene-packer',
+        'Scene.prototype.toCompendium',
+        async function (wrapped, ...args) {
+          const data = await wrapped.bind(this)(...args);
+          if (!data.thumb) {
+            // Create a thumbnail even if there is no background image
+            const t = await this.createThumbnail({img: data.img});
+            data.thumb = t?.thumb;
+          }
+          return data;
+        },
+        'WRAPPER',
+      );
+
+      libWrapper.register(
+        'scene-packer',
         'EntityCollection.prototype.importFromCollection',
         async function (wrapped, ...args) {
           // const [ collection, entryId, updateData, options ] = args;


### PR DESCRIPTION
- Scene thumbnails generate are now generated for tile only Scenes
  - Core v0.7.x normally require a Scene Background to generate a thumbnail.
- Added additional spacing to the Instance Prompt dialog.
- Downgraded several Errors to Warnings.