### PR TITLE
v2.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.15
+
+- Enhanced the `Asset Report`.
+  - Now limits asset validation to 10 concurrent requests to prevent server overloading/timing out requests.
+  - The report is now collapsed by default and will show a summary. Click on the heading to expand the section.
+  - Copying the report as JSON will now only copy the assets that have dependencies.
+
 ## v2.2.14
 
 - Scene thumbnails are now generated for tile only Scenes when exporting to a Compendium

--- a/languages/en.json
+++ b/languages/en.json
@@ -50,7 +50,7 @@
       "no-assets": "No Assets",
       "no-assets-details": "There are no assets in this world.",
       "processing-assets": "Processing assets",
-      "processing-assets-count": "Processing {count} assets..."
+      "processing-assets-count": "Validating {count} of {total} assets..."
     },
     "notifications": {
       "first-launch": "First launch of this Scene! Unpacking scene...",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/templates/asset-report/partials/details.html
+++ b/templates/asset-report/partials/details.html
@@ -17,7 +17,7 @@
       <li>
         <strong>Location:</strong> {{location}}<br>
         <strong>Asset:</strong> {{asset}}
-        <a href="{{asset}}" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+        <a href="{{asset}}" alt="Open in new tab" target="_blank"><i class="fas fa-external-link-alt"></i></a>
       </li>
       {{/if}}
       {{/each}}

--- a/templates/asset-report/report.html
+++ b/templates/asset-report/report.html
@@ -7,8 +7,8 @@
   <div class="report-details">
     {{#if scenes}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.scenes'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.scenes'}} ({{ dependencies.scenes }}/{{ scenes.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each scenes}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="Scene"}}
         {{/each}}
@@ -18,8 +18,8 @@
 
     {{#if journals}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.journals'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.journals'}} ({{ dependencies.journals }}/{{ journals.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each journals}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="JournalEntry"}}
         {{/each}}
@@ -29,8 +29,8 @@
 
     {{#if actors}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.actors'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.actors'}} ({{ dependencies.actors }}/{{ actors.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each actors}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="Actor"}}
         {{/each}}
@@ -40,8 +40,8 @@
 
     {{#if items}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.items'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.items'}} ({{ dependencies.items }}/{{ items.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each items}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="Item"}}
         {{/each}}
@@ -51,8 +51,8 @@
 
     {{#if macros}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.macros'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.macros'}} ({{ dependencies.macros }}/{{ macros.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each macros}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="Macro"}}
         {{/each}}
@@ -62,8 +62,8 @@
 
     {{#if playlists}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.playlists'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.playlists'}} ({{ dependencies.playlists }}/{{ playlists.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each playlists}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="Playlist"}}
         {{/each}}
@@ -73,8 +73,8 @@
 
     {{#if tables}}
     <section>
-      <h2>{{localize 'SCENE-PACKER.asset-report.tables'}}</h2>
-      <ul class="asset-list">
+      <h2><i class="fas fa-angle-double-down"></i> {{localize 'SCENE-PACKER.asset-report.tables'}} ({{ dependencies.tables }}/{{ tables.length }})</h2>
+      <ul class="asset-list hidden">
         {{#each tables}}
         {{> "modules/scene-packer/templates/asset-report/partials/details.html" entityType="RollTable"}}
         {{/each}}


### PR DESCRIPTION
- Enhanced the `Asset Report`.
  - Now limits asset validation to 10 concurrent requests to prevent server overloading/timing out requests.
  - The report is now collapsed by default and will show a summary. Click on the heading to expand the section.
  - Copying the report as JSON will now only copy the assets that have dependencies.