### PR TITLE
v2.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.2.18
+
+- Fixed `Relink compendium journal entries` macro in v0.8.x
+  - It now correctly locks and unlocks the compendium entries. Thanks Manfred.
+
 ## v2.2.17
 
 - Enhanced the `Asset Report`.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2575,7 +2575,8 @@ export default class ScenePacker {
           locked: locked,
         }),
       );
-      await game.settings.set('core', Compendium.CONFIG_SETTING, settings);
+      let configsetting = Compendium?.CONFIG_SETTING || CompendiumCollection?.CONFIG_SETTING || 'compendiumConfiguration';
+      await game.settings.set('core', configsetting, settings);
     }
   }
 


### PR DESCRIPTION
- Fixed `Relink compendium journal entries` macro in v0.8.x
  - It now correctly locks and unlocks the compendium entries. Thanks Manfred.