### PR TITLE
v2.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.2.21
+
+- Fixed packing Journal Pins in Core v0.8.3+
+  - Document validation added in v0.8.3 broke the additional data that gets added to the scene notes. Now fixed again. Thanks Bradfordly :)
+
 ## v2.2.20
 
 - Added ability to run the `Asset Report` against a module that contains compendium packs.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -849,7 +849,7 @@ export default class ScenePacker {
     const journalInfoResults = await Promise.allSettled(scene.data.notes.map(async note => {
       if (!isNewerVersion('0.8.0', game.data.version)) {
         // v0.8.0+ notes are documents now and stored in data
-        note = note.data;
+        note = note.data.toObject();
       }
       const journalData = game.journal.get(note.entryId);
       const compendiumJournal = await this.FindJournalInCompendiums(journalData, this.packs.journals);


### PR DESCRIPTION
- Fixed packing Journal Pins in Core v0.8.3+
  - Document validation added in v0.8.3 broke the additional data that gets added to the scene notes. Now fixed again. Thanks Bradfordly :)

Fixes #40 