### PR TITLE
2.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.24
+
+- Compatibility with Core v0.8.7
+- Better error handling when unpacking and importing entities.
+- Ensure Scene Packer flags are correctly saving when exporting to compendiums.
+
 ## v2.2.23
 
 - Enhanced the `Asset Report`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v2.2.24
 
 - Compatibility with Core v0.8.7
+- Improved the actor and journal matching that occurs when packing a Scene.
+  - This should help with cases where you have imported an Actor from a compendium, modified the Actor and then exported it to your compendium.
 - Better error handling when unpacking and importing entities.
 - Ensure Scene Packer flags are correctly saving when exporting to compendiums.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Compatibility with Core v0.8.7
 - Improved the actor and journal matching that occurs when packing a Scene.
   - This should help with cases where you have imported an Actor from a compendium, modified the Actor and then exported it to your compendium.
+- Tokens not representing an Actor will be excluded from being packed.
+  - This means that if you select "None" in the "Represented Actor" drop down, you can exclude certain Actors from being imported as part of the Scene unpacking process.
 - Better error handling when unpacking and importing entities.
 - Ensure Scene Packer flags are correctly saving when exporting to compendiums.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,6 @@ You can contact me on Discord `blair#9056` in the [<img src="https://github.com/
 
 If you are making money and utilising this module, please consider sending a few dollars my way and/or providing me with the cool adventures and modules you're building :)
 
-[![Patreon](https://img.shields.io/badge/patreon-donate-blue.svg)](https://www.patreon.com/blairm)
+[![Patreon](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Dblairm%26type%3Dpatrons&style=for-the-badge)](https://www.patreon.com/blairm)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/A0A0488MI)

--- a/languages/en.json
+++ b/languages/en.json
@@ -70,6 +70,7 @@
       "import-entities": {
         "creating-data": "Importing {count} new {type}.",
         "missing-name": "Tried to find an actor for a token with no name.",
+        "could-not-import": "Error importing entity",
         "invalid-packs": {
           "error": "Invalid pack configuration. Cannot import {type}. Check console for more details.",
           "short": "ImportEntities was called with no searchPacks defined.",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.2.23",
+  "version": "2.2.24",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",
-  "compatibleCoreVersion": "0.8.6",
+  "compatibleCoreVersion": "0.8.7",
   "author": "Blair McMillan",
   "authors": [
     {

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -1003,6 +1003,12 @@ export default class ScenePacker {
         }
         if (entity) {
           possibleMatches.push(entity);
+
+          if (entity.getFlag(MODULE_NAME, 'sourceId') === journal.uuid) {
+            // Entity in the pack originated in this world and is the exact journal
+            return entity;
+          }
+
           if (sourceId && entity.getFlag(MODULE_NAME, 'sourceId') === sourceId) {
             return entity;
           }
@@ -1010,8 +1016,23 @@ export default class ScenePacker {
       }
     }
 
+    if (possibleMatches.length === 1) {
+      // Only one Journal matches by name
+      return possibleMatches.pop();
+    }
+
+    if (possibleMatches.length) {
+      // See if there is a single entry in a compendium that belongs to this module
+      let filteredOptions = possibleMatches.filter(a => a.uuid.startsWith(`Compendium.${this.moduleName}.`));
+
+      if (filteredOptions.length === 1) {
+        // Only one Journal matches by name in a compendium belonging to this module
+        return filteredOptions.pop();
+      }
+    }
+
     const compendiumSourceId = journal.getFlag('core', 'sourceId');
-    if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}`))) {
+    if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
         return match;
@@ -1038,11 +1059,6 @@ export default class ScenePacker {
       );
 
       return compendiumJournal;
-    }
-
-    if (possibleMatches.length === 1) {
-      // Only one Journal matches by name
-      return possibleMatches.pop();
     }
 
     // There is more than one possible match, check the Journal contents for an exact match.
@@ -1130,6 +1146,12 @@ export default class ScenePacker {
         }
         if (entity) {
           possibleMatches.push(entity);
+
+          if (entity.getFlag(MODULE_NAME, 'sourceId') === actor.uuid) {
+            // Entity in the pack originated in this world and is the exact actor
+            return entity;
+          }
+
           if (sourceId && entity.getFlag(MODULE_NAME, 'sourceId') === sourceId) {
             return entity;
           }
@@ -1137,8 +1159,31 @@ export default class ScenePacker {
       }
     }
 
+    if (possibleMatches.length === 1) {
+      // Only one Actor matches by name
+      return possibleMatches.pop();
+    }
+
+    if (possibleMatches.length) {
+      // See if there is a single entry in a compendium that belongs to this module
+      let filteredOptions = possibleMatches.filter(a => a.uuid.startsWith(`Compendium.${this.moduleName}.`));
+
+      if (filteredOptions.length === 1) {
+        // Only one Actor matches by name in a compendium belonging to this module
+        return filteredOptions.pop();
+      }
+
+      // See if there is a single entry in a compendium that has the same image
+      filteredOptions = possibleMatches.filter(a => a.img === actor.img);
+
+      if (filteredOptions.length === 1) {
+        // Only one Actor matches by name and has the same image
+        return filteredOptions.pop();
+      }
+    }
+
     const compendiumSourceId = actor.getFlag('core', 'sourceId');
-    if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}`))) {
+    if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
         return match;
@@ -1165,11 +1210,6 @@ export default class ScenePacker {
       );
 
       return compendiumActor;
-    }
-
-    if (possibleMatches.length === 1) {
-      // Only one Actor matches by name
-      return possibleMatches.pop();
     }
 
     // There is more than one possible match, check the Actor contents for an exact match.
@@ -2604,7 +2644,7 @@ export default class ScenePacker {
     if (!scenePackerInstances?.length) {
       return;
     }
-    if (sourceId.startsWith('Compendium.scene-packer') || scenePackerInstances.some(p => sourceId.startsWith(`Compendium.${p}`))) {
+    if (sourceId.startsWith('Compendium.scene-packer') || scenePackerInstances.some(p => sourceId.startsWith(`Compendium.${p}.`))) {
       // Import was from an active Scene Packer compendium, update the default permission if possible
       const defaultPermission = entity.getFlag(MODULE_NAME, FLAGS_DEFAULT_PERMISSION);
       if (defaultPermission && typeof entity.data?.permission?.default !== 'undefined' && entity.data?.permission?.default !== defaultPermission) {
@@ -2708,9 +2748,9 @@ export default class ScenePacker {
             const possibleMatch = possibleMatches[m];
             let entity;
             if (!isNewerVersion('0.8.0', game.data.version)) {
-              entity = await p.getDocument(possibleMatch._id);;
+              entity = await p.getDocument(possibleMatch._id);
             } else {
-              entity = await p.getEntity(possibleMatch._id);;
+              entity = await p.getEntity(possibleMatch._id);
             }
             if (entity) {
               if (sourceId && entity.getFlag(MODULE_NAME, 'sourceId') === sourceId) {
@@ -2747,9 +2787,9 @@ export default class ScenePacker {
         const references = new Set();
         let journal;
         if (!isNewerVersion('0.8.0', game.data.version)) {
-          journal = await pack.getDocument(entry._id);;
+          journal = await pack.getDocument(entry._id);
         } else {
-          journal = await pack.getEntity(entry._id);;
+          journal = await pack.getEntity(entry._id);
         }
         if (!journal?.data?.content) {
           continue;

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -890,7 +890,7 @@ export default class ScenePacker {
     /**
      * tokenInfo is the data that gets passed to findMissingTokens
      */
-    const tokenInfoResults = await Promise.allSettled(scene.data.tokens.map(async token => {
+    const tokenInfoResults = await Promise.allSettled(scene.data.tokens.filter(a => a?.actorId || a?.data?.actorId).map(async token => {
       // Pull the sourceId of the actor, preferring the Actor entry in the module's compendium.
       let sourceId = '';
       let compendiumSourceId = '';

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2706,7 +2706,12 @@ export default class ScenePacker {
         if (possibleMatches.length) {
           for (let m = 0; m < possibleMatches.length; m++) {
             const possibleMatch = possibleMatches[m];
-            const entity = await p.getEntity(possibleMatch._id);
+            let entity;
+            if (!isNewerVersion('0.8.0', game.data.version)) {
+              entity = await p.getDocument(possibleMatch._id);;
+            } else {
+              entity = await p.getEntity(possibleMatch._id);;
+            }
             if (entity) {
               if (sourceId && entity.getFlag(MODULE_NAME, 'sourceId') === sourceId) {
                 // Direct match
@@ -2740,7 +2745,12 @@ export default class ScenePacker {
       }
       for (const entry of packValues) {
         const references = new Set();
-        const journal = await pack.getEntity(entry._id);
+        let journal;
+        if (!isNewerVersion('0.8.0', game.data.version)) {
+          journal = await pack.getDocument(entry._id);;
+        } else {
+          journal = await pack.getEntity(entry._id);;
+        }
         if (!journal?.data?.content) {
           continue;
         }
@@ -2936,7 +2946,12 @@ export default class ScenePacker {
 
           // Update the journal entry with the fully replaced content
           if (!dryRun) {
-            await pack.updateEntity({_id: entry._id, content: newContent});
+            if (!isNewerVersion('0.8.0', game.data.version)) {
+              const document = await pack.getDocument(entry._id);
+              await document.update({content: newContent}, {pack: pack.collection});
+            } else {
+              await pack.updateEntity({_id: entry._id, content: newContent});
+            }
           }
         } else {
           ScenePacker.logType(

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -1403,19 +1403,29 @@ export default class ScenePacker {
     });
 
     for (let i = 0; i < entities.length; i++) {
-      const entity = entities[i];
-      if (entity.uuid) {
-        const createdEntity = await this.ImportByUuid(entity.uuid);
-        if (createdEntity) {
-          createdEntities.push(createdEntity);
-          continue;
+      try {
+        const entity = entities[i];
+        if (entity.compendiumSourceId) {
+          const createdEntity = await this.ImportByUuid(entity.compendiumSourceId);
+          if (createdEntity) {
+            createdEntities.push(createdEntity);
+            continue;
+          }
         }
-      }
-      if (entity.compendiumSourceId) {
-        const createdEntity = await this.ImportByUuid(entity.compendiumSourceId);
-        if (createdEntity) {
-          createdEntities.push(createdEntity);
+        if (entity.uuid) {
+          const createdEntity = await this.ImportByUuid(entity.uuid);
+          if (createdEntity) {
+            createdEntities.push(createdEntity);
+          }
         }
+      } catch (e) {
+        this.logError(
+          true,
+          game.i18n.localize(
+            'SCENE-PACKER.notifications.import-entities.could-not-import',
+          ),
+          {entity: entities[i], type},
+        );
       }
     }
     if (createdEntities.length) {

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2717,7 +2717,7 @@ export default class ScenePacker {
         game.i18n.format(
           'SCENE-PACKER.world-conversion.compendiums.checking-and-updating',
           {
-            count: pack.index.length,
+            count: pack.index.length || pack.index.size,
           },
         ),
       );

--- a/scripts/wrapped.js
+++ b/scripts/wrapped.js
@@ -121,17 +121,19 @@ Hooks.once('setup', function () {
           `${item}.prototype.toCompendium`,
           function (wrapped, ...args) {
             // const [ pack ] = args;
+            let data = wrapped.bind(this)(...args);
+
             const newFlags = {};
             newFlags[ScenePacker.MODULE_NAME] = {sourceId: this.uuid};
-            if (this.data?.permission?.default) {
-              newFlags[ScenePacker.MODULE_NAME][ScenePacker.FLAGS_DEFAULT_PERMISSION] = this.data.permission.default;
+            if (data?.permission?.default) {
+              newFlags[ScenePacker.MODULE_NAME][ScenePacker.FLAGS_DEFAULT_PERMISSION] = data.permission.default;
             }
-            if (!this.data.flags) {
-              this.data.flags = {};
+            if (!data.flags) {
+              data.flags = {};
             }
-            mergeObject(this.data.flags, newFlags);
+            mergeObject(data.flags, newFlags);
 
-            return wrapped.bind(this)(...args);
+            return data;
           },
           'WRAPPER',
         );


### PR DESCRIPTION
- Compatibility with Core v0.8.7
- Improved the actor and journal matching that occurs when packing a Scene.
  - This should help with cases where you have imported an Actor from a compendium, modified the Actor and then exported it to your compendium.
- Tokens not representing an Actor will be excluded from being packed.
  - This means that if you select "None" in the "Represented Actor" drop down, you can exclude certain Actors from being imported as part of the Scene unpacking process.
- Better error handling when unpacking and importing entities.
- Ensure Scene Packer flags are correctly saving when exporting to compendiums.