### PR TITLE
v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.2
+
+- Fixed linking of Journal entries that contain spaces (was broken in v2.3.1).
+  - Thanks toastygm
+
 ## v2.3.1
 
 - Enhanced `Relink compendium journal entries` macro to support hyperlink style references such as:

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2948,7 +2948,7 @@ export default class ScenePacker {
     }
 
     // Matches things like: @Actor[obe2mDyYDXYmxHJb]{Something or other}
-    const rex = /@(\w+)\[(\w+)\]\{(\w+)\}/g;
+    const rex = /@(\w+)\[(\w+)\]\{([^}]+)\}/g;
     const domParser = new DOMParser();
 
     async function findNewReferences(type, oldRef, oldName, entry, journal) {


### PR DESCRIPTION
- Fixed linking of Journal entries that contain spaces (was broken in v2.3.1). Fixes #49 
  - Thanks toastygm