### PR TITLE
v2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## v.2.3.4
+## v2.3.5
+
+- If the [Compendium Folders](https://foundryvtt.com/packages/compendium-folders) module is enabled, make use of its internal functionality to create the folder structures if they exist.
+  - Will continue to do an approximation if `Compendium Folders` is not enabled.
+- Utilise the folder colour set via [Compendium Folders](https://foundryvtt.com/packages/compendium-folders).
+  - Note that if `Compendium Folders` is not enabled, the folder colours may not be quite as intended.
+
+## v2.3.4
 
 - Add error message when a scene with Journal Pins or Actor Tokens tries to be packed, but there aren't valid `journalPacks`/`creaturePacks` values defined for the module.
   - The console will try to suggest valid options for your module.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -108,3 +108,12 @@ export const CONSTANTS = Object.freeze({
     Scene: 'scenes',
   },
 });
+
+/**
+ * Fake Entity is used in place of a real entity, for times where operating against a real entity would throw errors.
+ * @type {{update: FakeEntity.update}}
+ */
+export const FakeEntity = {
+  update: () => {
+  },
+};


### PR DESCRIPTION
- If the [Compendium Folders](https://foundryvtt.com/packages/compendium-folders) module is enabled, make use of its internal functionality to create the folder structures if they exist.
  - Will continue to do an approximation if `Compendium Folders` is not enabled.
- Utilise the folder colour set via [Compendium Folders](https://foundryvtt.com/packages/compendium-folders).
  - Note that if `Compendium Folders` is not enabled, the folder colours may not be quite as intended.
  - Mostly resolves #53 although it doesn't handle font colours.