### PR TITLE
v2.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.8
+
+- Fixed bug where Journals and Actors might be imported multiple times if an entry can't be found in the compendiums. Thanks `OwlbearAviary` and `WarVisionary` for the data to be able to replicate the issue.
+
 ## v2.3.7
 
 - Manually clearing a Scene's packed data will now also reset which module it is packed against.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.3.8
 
+- Fixed bug where `Import All` would import entities multiple times when multiple packs of the same type existed in a module.
 - Fixed bug where Journals and Actors might be imported multiple times if an entry can't be found in the compendiums. Thanks `OwlbearAviary` and `WarVisionary` for the data to be able to replicate the issue.
 
 ## v2.3.7

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -212,7 +212,6 @@ export default class ScenePacker {
     });
     di.render(true);
     for (let i = 0; i < CONSTANTS.PACK_IMPORT_ORDER.length; i++) {
-      let createData = [];
       const packType = CONSTANTS.PACK_IMPORT_ORDER[i];
       di.data.content = `<p>${game.i18n.format('SCENE-PACKER.welcome.import-all.wait', {
         type: game.i18n.format(CONSTANTS.TYPE_HUMANISE[packType]),
@@ -229,6 +228,7 @@ export default class ScenePacker {
         },
       );
       for (let i = 0; i < packs.length; i++) {
+        let createData = [];
         const pack = packs[i];
         try {
           let entityClass;

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -1682,7 +1682,7 @@ export default class ScenePacker {
       // No missing entities
       return createdEntities;
     }
-    let entityNames = entities.map(e => e.name || e.journalName || e.tokenName || e.actorName);
+    let entityNames = entities.map(e => e.name || e.journalName || e.tokenName || e.actorName || e.text);
 
     if (!type) {
       type = 'entities';
@@ -1928,6 +1928,7 @@ export default class ScenePacker {
 
       // Filter down to those that are still missing
       entities = entities.filter(e => !collection.find(f => f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === e.sourceId));
+      entityNames = entities.map(e => e.name || e.journalName || e.tokenName || e.actorName || e.text);
 
       // Filter to just the needed entities
       const content = packContent.filter((entity) =>
@@ -1937,7 +1938,7 @@ export default class ScenePacker {
       // Remove the entries that we found in this pack
       entities = entities.filter(
         (e) =>
-          content.find((entity) => entity.name === (e.name || e.journalName || e.tokenName || e.actorName)) == null,
+          content.find((entity) => entity.name === (e.name || e.journalName || e.tokenName || e.actorName || e.text)) == null,
       );
 
       if (content.length > 0) {


### PR DESCRIPTION
- Fixed bug where `Import All` would import entities multiple times when multiple packs of the same type existed in a module.
- Fixed bug where Journals and Actors might be imported multiple times if an entry can't be found in the compendiums. Thanks `OwlbearAviary` and `WarVisionary` for the data to be able to replicate the issue.