### PR TITLE
v2.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.10
+
+- Scene Packer will no longer change valid note icons.
+  - Fixes issue [#60](https://github.com/League-of-Foundry-Developers/scene-packer/issues/60) reported by toastygm
+
 ## v2.3.9
 
 - Added ability to relink entries across modules.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2409,17 +2409,10 @@ export default class ScenePacker {
     }
 
     function getIconForNote(note) {
-      // Replace icon with a Book if Automatic Journal Icon Numbers isn't installed or the image doesn't exist yet.
+      // Replace icon with a Book if the image doesn't exist.
       let icon = note.icon;
-      if (
-        (icon.startsWith('modules/journal-icon-numbers/') || note?.flags?.autoIconFlags) &&
-        !game.modules.get('journal-icon-numbers')?.active
-      ) {
-        icon = 'icons/svg/book.svg';
-      } else {
-        // Test the icon exists and replace it if it doesn't
-        $.get(icon).fail(() => icon = 'icons/svg/book.svg');
-      }
+      // Test the icon exists and replace it if it doesn't
+      $.get(icon).fail(() => icon = 'icons/svg/book.svg');
       return icon;
     }
 


### PR DESCRIPTION
- Scene Packer will no longer change valid note icons.
  - Fixes issue [#60](https://github.com/League-of-Foundry-Developers/scene-packer/issues/60) reported by toastygm