### PR TITLE
v2.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.12
+
+- Updated the `Relink compendium entries` macro to handle the case where *only* hyperlink style links exist within a journal. 
+  - Previously the updates would only occur if at least one Foundry VTT style link existed.
+
 ## v2.3.11
 
 - Updated the `Relink compendium entries` macro to now also search within Item descriptions for references to other entries.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -3142,6 +3142,7 @@ export default class ScenePacker {
         if (!content) {
           continue;
         }
+        const originalContent = content;
         ScenePacker.logType(
           moduleName,
           'info',
@@ -3157,6 +3158,7 @@ export default class ScenePacker {
         );
 
         // Replace hyperlink style links first
+        let hyperlinksChanged = 0;
         const doc = domParser.parseFromString(content, 'text/html');
         for (const link of doc.getElementsByTagName('a')) {
           if (!link.classList.contains('entity-link') || !link.dataset.entity || !link.dataset.id) {
@@ -3190,6 +3192,7 @@ export default class ScenePacker {
           if (!dryRun) {
             link.setAttribute('data-pack', newRef[0].pack);
             link.setAttribute('data-id', newRef[0].ref);
+            hyperlinksChanged++;
           }
         }
         if (!dryRun) {
@@ -3223,7 +3226,7 @@ export default class ScenePacker {
           await ScenePacker.RelinkQuickEncounterData(document, moduleName, dryRun);
         }
 
-        if (references.size) {
+        if (references.size || content !== originalContent) {
           ScenePacker.logType(
             moduleName,
             'info',
@@ -3231,7 +3234,7 @@ export default class ScenePacker {
             game.i18n.format(
               'SCENE-PACKER.world-conversion.compendiums.updating-references',
               {
-                count: new Intl.NumberFormat().format(references.size),
+                count: new Intl.NumberFormat().format(references.size + hyperlinksChanged),
                 name: document.name,
                 type: typeName,
               },
@@ -3274,7 +3277,7 @@ export default class ScenePacker {
             game.i18n.format(
               'SCENE-PACKER.world-conversion.compendiums.updating-reference',
               {
-                count: new Intl.NumberFormat().format(references.size),
+                count: new Intl.NumberFormat().format(references.size + hyperlinksChanged),
                 name: document.name,
               },
             ),


### PR DESCRIPTION
- Updated the `Relink compendium entries` macro to handle the case where *only* hyperlink style links exist within a journal. 
  - Previously the updates would only occur if at least one Foundry VTT style link existed.