### PR TITLE
v2.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v2.3.20
 
+- Allow journal unpacking to find by compendium reference as well.
+  - This improves the likelihood of unpacking correctly, even if the IDs changed over time.
+- Fixed a bug where tokens wouldn't correctly link to system compendiums, depending on how the module was initialised.
 - Updated the `Show Scenes Worth Packing` macro display why a Scene should be packed and also added basic "verification" support to compare the compendium packs against the local scene data.
   - The verify step does not compare the packed data, it only checks for the presence of packed data. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - This improves the likelihood of unpacking correctly, even if the IDs changed over time.
 - Fixed a bug where tokens wouldn't correctly link to system compendiums, depending on how the module was initialised.
 - Updated the `Show Scenes Worth Packing` macro display why a Scene should be packed and also added basic "verification" support to compare the compendium packs against the local scene data.
-  - The verify step does not compare the packed data, it only checks for the presence of packed data. 
+  - The verify step does not compare the packed data, it only checks for the presence of packed data.
 
 ## v2.3.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.20
+
+- Updated the `Show Scenes Worth Packing` macro display why a Scene should be packed and also added basic "verification" support to compare the compendium packs against the local scene data.
+  - The verify step does not compare the packed data, it only checks for the presence of packed data. 
+
 ## v2.3.19
 
 - Added missing support for RollTable packing and unpacking within [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles).

--- a/languages/en.json
+++ b/languages/en.json
@@ -30,7 +30,16 @@
     },
     "worth-packing": {
       "title": "Scenes worth packing",
-      "intro": "The following {count} of {total} Scene/s are worth packing:",
+      "intro": "The following {count} of {total} Scene/s are worth packing if you haven't already:",
+      "verify": "Verify compendium packs",
+      "verify-intro": "<p>Verify that the scenes present in your world are also present in your module compendiums and contain packed data.</p><p><strong>Please note:</strong> this process will not verify that the packed data is the same, it merely ensures that packed data is present in the compendiums.</p>",
+      "verify-select": "Select the module containing the compendium packs you wish to verify:",
+      "verify-slow": "<strong>Please note:</strong> This process may take a while depending on how many scenes you have.",
+      "verify-wait": "Please wait...",
+      "verify-missing": "The following {count} of {total} Scene/s in the compendiums belonging to \"{module}\" may have issues:",
+      "verify-ok": "All scenes were found in the compendiums belonging to \"{module}\".",
+      "verify-not-found": "missing",
+      "verify-not-packed": "no packed data",
       "none": "There are no Scenes that contain data worth packing."
     },
     "asset-report": {

--- a/module.json
+++ b/module.json
@@ -2,11 +2,11 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.19",
+  "version": "2.3.20",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",
-  "compatibleCoreVersion": "0.8.8",
+  "compatibleCoreVersion": "0.8.9",
   "author": "Blair McMillan",
   "authors": [
     {

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -435,7 +435,7 @@ export default class ScenePacker {
             let sourceId = e.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
             let coreSourceId = e.getFlag('core', 'sourceId');
             if (sourceId || coreSourceId) {
-              const existingEntries = collection.filter(f => f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sourceId || f.getFlag('core', 'sourceId') === sourceId);
+              const existingEntries = collection.filter(f => (sourceId && f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sourceId) || (coreSourceId && f.getFlag('core', 'sourceId') === coreSourceId));
               if (existingEntries.length && forceImport && renameOriginals) {
                 // Update the existing entry names
                 const newFlags = {};


### PR DESCRIPTION
- Allow journal unpacking to find by compendium reference as well.
  - This improves the likelihood of unpacking correctly, even if the IDs changed over time.
- Fixed a bug where tokens wouldn't correctly link to system compendiums, depending on how the module was initialised.
- Updated the `Show Scenes Worth Packing` macro display why a Scene should be packed and also added basic "verification" support to compare the compendium packs against the local scene data.
  - The verify step does not compare the packed data, it only checks for the presence of packed data.