### PR TITLE
v2.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.3.29
+
+- Updated functionality for [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) and [Quick Encounters](https://foundryvtt.com/packages/quick-encounters).
+  - Supports new data references added by Monk's Active Tile Triggers.
+    - Scene teleport syntax.
+    - Rolltable syntax.
+  - Supports new active tile's created by Quick Encounters.
+
 ## v2.3.28
 
 - Fixed issue where an Actor, JournalEntry or Macro would incorrectly show as missing in the original source world due to data flags not existing on the source document.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.28",
+  "version": "2.3.29",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5274,7 +5274,6 @@ Hooks.on('createScene', async function (s) {
  */
 
 Hooks.on('preCreateTile', async function (document) {
-  debugger;
   const moduleName = getProperty(document.data, 'flags.scene-packer.source-module');
   if (!moduleName) {
     return;


### PR DESCRIPTION
- Updated functionality for [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) and [Quick Encounters](https://foundryvtt.com/packages/quick-encounters).
  - Supports new data references added by Monk's Active Tile Triggers.
    - Scene teleport syntax.
    - Rolltable syntax.
  - Supports new active tile's created by Quick Encounters.