### PR TITLE
v2.3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.30
+
+- Fixed issue where packing a scene would not identify any [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) to pack.
+
 ## v2.3.29
 
 - Updated functionality for [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) and [Quick Encounters](https://foundryvtt.com/packages/quick-encounters).

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.29",
+  "version": "2.3.30",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -3625,7 +3625,7 @@ export default class ScenePacker {
    * @return {Promise<Object[]>}
    */
   async packActiveTiles(tiles) {
-    if (!tiles?.length) {
+    if (!tiles?.length && !tiles?.size) {
       return [];
     }
 


### PR DESCRIPTION
- Fixed issue where packing a scene would not identify any [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) to pack.