### PR TITLE
v2.3.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.3.31
 
+- Support folder sorting via [Compendium Folders](https://github.com/earlSt1/vtt-compendium-folders/pull/135).
 - Fixed another interaction issue between [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) and [Quick Encounters](https://foundryvtt.com/packages/quick-encounters).
   - MATT values would be updated correctly, but wouldn't persist after a refresh. This has now been fixed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.31
+
+- Fixed another interaction issue between [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) and [Quick Encounters](https://foundryvtt.com/packages/quick-encounters).
+  - MATT values would be updated correctly, but wouldn't persist after a refresh. This has now been fixed.
+
 ## v2.3.30
 
 - Fixed issue where packing a scene would not identify any [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) to pack.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.3.30",
+  "version": "2.3.31",
   "library": "true",
   "manifestPlusVersion": "1.1.0",
   "minimumCoreVersion": "0.7.9",
@@ -64,7 +64,7 @@
   "manifest": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/latest/download/module.json",
   "download": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/latest/download/module.zip",
   "bugs": "https://github.com/League-of-Foundry-Developers/scene-packer/issues",
-  "changelog": "https://github.com/League-of-Foundry-Developers/scene-packer/blob/master/changelog.md",
+  "changelog": "https://github.com/League-of-Foundry-Developers/scene-packer/blob/master/CHANGELOG.md",
   "flags": {
     "allowBugReporter": true
   },

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -3503,7 +3503,8 @@ export default class ScenePacker {
         )
       }
       const activeTileResponse = await this.unpackActiveTiles(ScenePacker.GetActiveTilesData(scene.data.tiles), tilesInfo);
-      if (activeTileResponse?.tilesCount && activeTileResponse?.actionsCount) {
+      if (activeTileResponse?.tilesCount && activeTileResponse?.actionsCount && activeTileResponse?.updates?.length) {
+        await scene.updateEmbeddedDocuments('Tile', activeTileResponse.updates);
         this.log(
           true,
           game.i18n.format(
@@ -3621,7 +3622,7 @@ export default class ScenePacker {
     );
   }/**
    * Returns packed active tile data for the provided tiles
-   * @param {Object[]} tiles - The tiles which might contain Monk's Active Tile Trigger data
+   * @param {Object[]|EmbeddedCollection} tiles - The tiles which might contain Monk's Active Tile Trigger data
    * @return {Promise<Object[]>}
    */
   async packActiveTiles(tiles) {
@@ -3702,7 +3703,7 @@ export default class ScenePacker {
    * Unpacks the macros associated with Monk's Active Tiles
    * @param {Object[]|EmbeddedCollection} tiles - The tiles which might contain Monk's Active Tiles actions
    * @param {Object[]} tilesInfo - The tiles which contain Monk's Active Tiles data
-   * @return {Promise<{tilesCount: Number, actionsCount: Number}>}
+   * @return {Promise<{tilesCount: Number, actionsCount: Number, updates: Object[]}>}
    */
   async unpackActiveTiles(tiles, tilesInfo) {
     let tilesCount = 0;
@@ -3749,8 +3750,9 @@ export default class ScenePacker {
       return newEntity;
     }
 
+    const updates = [];
     for (const tile of tiles) {
-      const tileInfo = tilesInfo?.find(t => t.tileID === tile.id);
+      const tileInfo = tilesInfo?.find(t => t.tileID === (tile.id || tile._id));
       if (!tileInfo) {
         continue;
       }
@@ -3868,19 +3870,18 @@ export default class ScenePacker {
 
       if (changed) {
         tilesCount++;
-        let newActions = {};
-        setProperty(newActions, 'flags.monks-active-tiles.actions', actions);
-        if (tile.data?.flags) {
-          await tile.data.update(newActions);
-        } else if (tile.flags) {
-          await tile.update(newActions);
-        }
+        const update = {
+          _id: tile.id || tile._id,
+        };
+        setProperty(update, 'flags.monks-active-tiles.actions', actions);
+        updates.push(update);
       }
     }
 
     return {
       tilesCount,
       actionsCount,
+      updates,
     }
   }
 
@@ -4046,9 +4047,28 @@ export default class ScenePacker {
         }
       }
 
-      if (quickEncounter.savedTilesData && quickEncounter.savedTilesData.length && quickEncounter.SPTileData && quickEncounter.SPTileData.length) {
-        const activeTileResponse = await this.unpackActiveTiles(quickEncounter.savedTilesData, quickEncounter.SPTileData);
-        if (activeTileResponse?.tilesCount || activeTileResponse?.actionsCount) {
+      if (quickEncounter.savedTilesData && quickEncounter.savedTilesData.length) {
+        let updatedTiles = 0;
+        for (const savedTile of quickEncounter.savedTilesData) {
+          const SPTileData = getProperty(savedTile, 'flags.scene-packer.SPTileData');
+          if (!SPTileData) {
+            continue;
+          }
+
+          const activeTileResponse = await this.unpackActiveTiles([savedTile], SPTileData);
+          if (activeTileResponse?.updates?.length) {
+            for (const update of activeTileResponse.updates) {
+              if (savedTile._id !== update._id) {
+                continue;
+              }
+
+              mergeObject(savedTile, update);
+              updatedTiles++;
+            }
+          }
+        }
+
+        if (updatedTiles) {
           updates.push({
             type: 'Tile',
             name: "Monk's Active Tile Triggers",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -500,6 +500,11 @@ export default class ScenePacker {
                 }
               }
 
+              // Set the sorting value
+              if (cData.flags?.cf?.sort) {
+                cData.sort = cData.flags.cf.sort;
+              }
+
               // Patch "Sight angle must be between 1 and 360 degrees." error
               if (packType === 'Actor') {
                 if (cData.token?.sightAngle === 0) {
@@ -663,6 +668,12 @@ export default class ScenePacker {
       if (response.folderMap.has(cfPath)) {
         continue;
       }
+      let cfSorting = entity.data?.flags?.cf?.sorting;
+      const cfSort = entity.data?.flags?.cf?.sort;
+      if (cfSort && !cfSorting) {
+        // This document has a sort value, so it implies manual folder sorting
+        cfSorting = 'm';
+      }
 
       const pathParts = cfPath.split(CONSTANTS.CF_SEPARATOR);
       for (let j = 0; j < pathParts.length; j++) {
@@ -692,6 +703,7 @@ export default class ScenePacker {
           type: entityType,
           parent: parent?.id || null,
           color: cfColor || null,
+          sorting: cfSorting,
         });
         response.folderMap.set(pathPart, folder);
       }
@@ -2568,6 +2580,11 @@ export default class ScenePacker {
             }
             cData['flags.core.sourceId'] = c.uuid;
 
+            // Set the sorting value
+            if (cData.flags?.cf?.sort) {
+              cData.sort = cData.flags.cf.sort;
+            }
+
             // Patch "Sight angle must be between 1 and 360 degrees." error
             if (cData.token?.sightAngle === 0) {
               cData.token.sightAngle = 360;
@@ -3399,6 +3416,11 @@ export default class ScenePacker {
       update.folder = folderData.folderMap.get(cfPath)?.id || null;
     } else if (folderData.folderId) {
       update.folder = folderData.folderId;
+    }
+
+    // Set the sorting value
+    if (entity.data?.flags?.cf?.sort) {
+      update.sort = entity.data.flags.cf.sort;
     }
 
     if (!isNewerVersion('0.8.0', game.data.version)) {


### PR DESCRIPTION
- Support folder sorting via [Compendium Folders](https://github.com/earlSt1/vtt-compendium-folders/pull/135).
- Fixed another interaction issue between [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles) and [Quick Encounters](https://foundryvtt.com/packages/quick-encounters).
  - MATT values would be updated correctly, but wouldn't persist after a refresh. This has now been fixed.