### PR TITLE
v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added configurable asset timeout.
   - This is used as part of the Moulinette integration and can be adjusted to suit your needs based on your download speed. Particularly useful if you are loading in assets that are large such as animated videos.
+- Fixed a bug where unpacking a scene wouldn't correctly identify Journals as missing.
 
 ## v2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.5.1
+
+- Added configurable asset timeout.
+  - This is used as part of the Moulinette integration and can be adjusted to suit your needs based on your download speed. Particularly useful if you are loading in assets that are large such as animated videos.
+
 ## v2.5.0
 
 - Removed support for v0.7.X of Foundry VTT.

--- a/languages/en.json
+++ b/languages/en.json
@@ -326,6 +326,8 @@
       "name": "Export to Moulinette",
       "label": "Open Exporter wizard",
       "hint": "The exporter wizard will allow you to package up an adventure for distribution via Moulinette Cloud.",
+      "timeout": "Asset timeout",
+      "timeout-help": "The amount of time in seconds to wait for an asset to be downloaded. Set to 0 to disable timeouts.",
       "unsupported": "Export to Moulinette is only supported in versions >= 0.8.0",
       "selected-count": "{count} entities selected for export.",
       "toggle-checkboxes": "Toggle All Checkboxes",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/asset-report.js
+++ b/scripts/asset-report.js
@@ -423,22 +423,33 @@ export default class AssetReport extends FormApplication {
 
   /**
    * Wrapper around {@link fetch} to include a timeout.
-   * Defaults to 5sec.
    * @param {RequestInfo} resource
-   * @param {RequestInit} options
+   * @param {RequestInit} [options]
    * @return {Promise<Response>}
    */
   static async FetchWithTimeout(resource, options) {
-    const {timeout = 5000} = options;
+    let timeout = game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ASSET_TIMEOUT) || 60;
+    if (options?.timeout) {
+      timeout = options.timeout;
+    }
+    if (timeout < 0) {
+      timeout = 5;
+    }
+    timeout = timeout * 1000;
 
     const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), timeout);
+    let id;
+    if (timeout) {
+      id = setTimeout(() => controller.abort(), timeout);
+    }
 
     const response = await fetch(resource, {
       ...options,
       signal: controller.signal,
     });
-    clearTimeout(id);
+    if (id) {
+      clearTimeout(id);
+    }
 
     return response;
   }

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -125,6 +125,11 @@ export const CONSTANTS = Object.freeze({
   PACK_IMPORT_ORDER: ['Playlist', 'Macro', 'Item', 'Actor', 'Cards', 'RollTable', 'JournalEntry', 'Scene'],
 
   /**
+   * The setting key for tracking the timeout value when processing assets.
+   */
+  SETTING_ASSET_TIMEOUT: 'assetTimeout',
+
+  /**
    * The setting key for whether to display the context menu on the Scene sidebar.
    */
   SETTING_ENABLE_CONTEXT_MENU: 'enableContextMenu',

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -819,7 +819,7 @@ export default class MoulinetteImporter extends FormApplication {
    * @return {Promise<Object>}
    */
   async fetchData(url) {
-    const response = await Compressor.FetchWithTimeout(url, {timeout: 60000});
+    const response = await Compressor.FetchWithTimeout(url);
     if (!response.ok) {
       throw game.i18n.format('SCENE-PACKER.importer.invalid-url', {
         url,
@@ -867,7 +867,7 @@ export default class MoulinetteImporter extends FormApplication {
    */
   async fetchDataIfMissing(url, collection, onlyIDs = []) {
     // TODO Look into a nice way to handle updating existing data.
-    const response = await Compressor.FetchWithTimeout(url, {timeout: 60000});
+    const response = await Compressor.FetchWithTimeout(url);
     if (!response.ok) {
       throw game.i18n.format('SCENE-PACKER.importer.invalid-url', {
         url,

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5305,6 +5305,15 @@ Hooks.once('setup', () => {
     restricted: true,
   })
 
+  game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ASSET_TIMEOUT, {
+    name: game.i18n.localize('SCENE-PACKER.exporter.timeout'),
+    hint: game.i18n.localize('SCENE-PACKER.exporter.timeout-help'),
+    scope: 'client',
+    config: true,
+    type: Number,
+    default: 120,
+  });
+
   game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_AUTHOR, {
     scope: 'client',
     config: false,

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2640,8 +2640,11 @@ export default class ScenePacker {
         .filter((info) => {
           // Filter for only the entries that are missing, or are in a different folder.
           const j = game.journal.getName(info?.journalName);
+          if (!j) {
+            return true;
+          }
           const jData = CONSTANTS.IsV10orNewer() ? j : j.data;
-          return j == null || (folderIDs.length && !folderIDs.includes(jData.folder));
+          return folderIDs.length && !folderIDs.includes(jData.folder);
         });
     }
 
@@ -2701,8 +2704,11 @@ export default class ScenePacker {
         .filter((info) => {
           // Filter for only the entries that are missing, or are in a different folder.
           const m = game.macros.getName(info?.name);
+          if (!m) {
+            return true;
+          }
           const mData = CONSTANTS.IsV10orNewer() ? m : m.data;
-          return m == null || (folderIDs.length && !folderIDs.includes(mData.folder));
+          return folderIDs.length && !folderIDs.includes(mData.folder);
         });
     }
 


### PR DESCRIPTION
- Added configurable asset timeout.
  - This is used as part of the Moulinette integration and can be adjusted to suit your needs based on your download speed. Particularly useful if you are loading in assets that are large such as animated videos.
- Fixed a bug where unpacking a scene wouldn't correctly identify Journals as missing.