### PR TITLE
v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.5.3
+
+- Handle the case where an actor on a scene is a duplicate of another existing actor, but renamed.
+  - Fixes a bug where a token would not be relinked correctly due to the mismatch.
+- Wait for Actors to finish be imported when unpacking a scene to avoid edge cases due to timing issues.
+- Switch away from using deprecated RollTable functions in V10.
+- Added new format for V10 compatibility definition.
+
 ## v2.5.2
 
 - Fixed incorrect version checking which would mark packaged modules as outdated.

--- a/module.json
+++ b/module.json
@@ -2,11 +2,16 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",
   "compatibleCoreVersion": "10",
+  "compatibility": {
+    "minimum": "0.8.6",
+    "verified": 10,
+    "maximum": 10
+  },
   "author": "Blair McMillan",
   "authors": [
     {

--- a/scripts/export-import/converter.js
+++ b/scripts/export-import/converter.js
@@ -224,7 +224,7 @@ export function ReplaceCompendiumReferences(context, documents, availableDocumen
           continue;
         }
 
-        if (typeof oldValue === 'object' && oldValue._id && oldValue.collection && oldValue.resultId) {
+        if (typeof oldValue === 'object' && oldValue._id && (oldValue.documentCollection ?? oldValue.collection) && (oldValue.documentId ?? oldValue.resultId)) {
           // This is a roll table result.
           updates.push({
             _id: dataId,

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -572,11 +572,19 @@ export default class MoulinetteImporter extends FormApplication {
               continue;
             }
 
-            await table.updateEmbeddedDocuments('TableResult', {
-              _id: tableUpdate.embeddedId,
-              collection: tableUpdate.collection,
-              resultId: tableUpdate.resultId,
-            });
+            if (CONSTANTS.IsV10orNewer()) {
+              await table.updateEmbeddedDocuments('TableResult', {
+                _id: tableUpdate.embeddedId,
+                documentCollection: tableUpdate.collection,
+                documentId: tableUpdate.resultId,
+              });
+            } else {
+              await table.updateEmbeddedDocuments('TableResult', {
+                _id: tableUpdate.embeddedId,
+                collection: tableUpdate.collection,
+                resultId: tableUpdate.resultId,
+              });
+            }
           }
         }
         console.groupEnd();

--- a/scripts/export-import/related/rolltable.js
+++ b/scripts/export-import/related/rolltable.js
@@ -18,8 +18,8 @@ export function ExtractRelatedRollTableData(table) {
   const tableData = CONSTANTS.IsV10orNewer() ? table : table.data;
   for (const result of tableData?.results) {
     const resultData = CONSTANTS.IsV10orNewer() ? result : result.data;
-    let collection = resultData?.collection;
-    const resultId = resultData?.resultId;
+    let collection = CONSTANTS.IsV10orNewer() ? resultData?.documentCollection : resultData?.collection;
+    const resultId = CONSTANTS.IsV10orNewer() ? resultData?.documentId : resultData?.resultId;
 
     if (!CONSTANTS.PACK_IMPORT_ORDER.includes(collection)) {
       // Make the uuid reference consistent with "standard" ones.

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -2773,7 +2773,7 @@ export default class ScenePacker {
     if (actorId) {
       const tData = tokenWorldData.find(t => t.sourceId === `Actor.${actorId}` && t.compendiumSourceId);
       if (tData) {
-        const actor = game.actors.contents.find(a => a.getFlag('core', 'sourceId') === tData.compendiumSourceId && !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated'));
+        const actor = game.actors.contents.find(a => (a.getFlag('core', 'sourceId') === tData.compendiumSourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === tData.sourceId) && !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated'));
         if (actor) {
           return actor;
         }
@@ -3219,6 +3219,10 @@ export default class ScenePacker {
       const coreSourceId = p.getFlag('core', 'sourceId');
       const sourceId = p.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
 
+      if (entity.name !== p.name) {
+        return false;
+      }
+
       if (hasUuid && coreSourceId === entity.uuid) {
         return true;
       }
@@ -3280,7 +3284,7 @@ export default class ScenePacker {
       update.sort = entityData.flags.cf.sort;
     }
 
-    return collection.importFromCompendium(game.packs.get(entity.compendium.collection), entity.id, update, {keepId: true});
+    return await collection.importFromCompendium(game.packs.get(entity.compendium.collection), entity.id, update, {keepId: true});
   }
 
   /**
@@ -4469,8 +4473,8 @@ export default class ScenePacker {
             // Rolltables don't have content like normal but instead have references to other results
             const results = CONSTANTS.IsV10orNewer() ? document?.results : document?.data?.results;
             for (const result of results || []) {
-              const resultId = CONSTANTS.IsV10orNewer() ? result?.resultId : result?.data?.resultId;
-              const collection = CONSTANTS.IsV10orNewer() ? result?.collection : result?.data?.collection;
+              const resultId = CONSTANTS.IsV10orNewer() ? result?.documentId : result?.data?.resultId;
+              const collection = CONSTANTS.IsV10orNewer() ? result?.documentCollection : result?.data?.collection;
               if (!resultId || !collection) {
                 // This result is not a reference to another entity
                 continue;


### PR DESCRIPTION
- Handle the case where an actor on a scene is a duplicate of another existing actor, but renamed.
  - Fixes a bug where a token would not be relinked correctly due to the mismatch.
- Wait for Actors to finish be imported when unpacking a scene to avoid edge cases due to timing issues.
- Switch away from using deprecated RollTable functions in V10.
- Added new format for V10 compatibility definition.