### PR TITLE
v2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5.5
+- Fixed a bug that was preventing Quick Encounters from being relinked correctly.
+  - The bug was introduced in v2.5.0 as part of the v10 changes.
+
 ## v2.5.4
 - Adjusted the way in which packs are searched, to handle an edge case where a pack might be referenced, but not available.
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5007,7 +5007,7 @@ export default class ScenePacker {
       if (!dryRun) {
         let newFlags = {};
         setProperty(newFlags, 'flags.quick-encounters.quickEncounter', JSON.stringify(quickEncounter));
-        await journalData.update(newFlags);
+        await journal.update(newFlags);
       }
     }
   }


### PR DESCRIPTION
- Fixed a bug that was preventing Quick Encounters from being relinked correctly.
  - The bug was introduced in v2.5.0 as part of the v10 changes.