### PR TITLE
v2.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.5.6
+
+- Fixed long-standing Asset Report bug where it would incorrectly mark http/https assets as "External" regardless of what the checkbox was set to.
+- Fixed issue where Asset Report would mark assets as "External" even if they are part of an "allowed" module.
+  - Issue was introduced as part of the changes to support v10.
+
 ## v2.5.5
 - Fixed a bug that was preventing Quick Encounters from being relinked correctly.
   - The bug was introduced in v2.5.0 as part of the v10 changes.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/asset-report.js
+++ b/scripts/asset-report.js
@@ -237,7 +237,6 @@ export default class AssetReport extends FormApplication {
           assetRequests[index] = assetRequest;
           assetResponses[index] = await AssetReport.FetchWithTimeout(assetRequest, {
             method: 'HEAD',
-            mode: 'no-cors',
           });
         }
       };

--- a/scripts/asset-report/module-select.js
+++ b/scripts/asset-report/module-select.js
@@ -62,6 +62,7 @@ export default class ModuleSelect extends FormApplication {
       } else {
         mod = m.data.toObject();
       }
+      mod.id = m.id;
       mod.activeModule = m.active;
       mod.hasPacks = mod.packs.length > 0;
       mod.hasScripts = mod.scripts.length > 0;


### PR DESCRIPTION
- Fixed long-standing Asset Report bug where it would incorrectly mark http/https assets as "External" regardless of what the checkbox was set to.
- Fixed issue where Asset Report would mark assets as "External" even if they are part of an "allowed" module.
  - Issue was introduced as part of the changes to support v10.