### PR TITLE
v2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.5.7
+
+- Fixed issue with the Moulinette importer where asset references would point to the wrong place if you are using an S3 bucket.
+  - It was failing to use the S3 bucket URL prefix.
+
 ## v2.5.6
 
 - Fixed long-standing Asset Report bug where it would incorrectly mark http/https assets as "External" regardless of what the checkbox was set to.

--- a/module.json
+++ b/module.json
@@ -1,8 +1,9 @@
 {
+  "id": "scene-packer",
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",
@@ -33,13 +34,13 @@
     {
       "type": "video",
       "url": "https://www.youtube.com/watch?v=cG6qtoZPczI",
-      "thumbnail": "http://img.youtube.com/vi/cG6qtoZPczI/0.jpg",
+      "thumbnail": "https://img.youtube.com/vi/cG6qtoZPczI/0.jpg",
       "caption": "Scene Packer - How to convert a World to a Module (The Sky Isles)"
     },
     {
       "type": "video",
       "url": "https://www.youtube.com/watch?v=XZjuE1j_7GQ",
-      "thumbnail": "http://img.youtube.com/vi/XZjuE1j_7GQ/0.jpg",
+      "thumbnail": "https://img.youtube.com/vi/XZjuE1j_7GQ/0.jpg",
       "caption": "Scene Packer and Moulinette Integration"
     }
   ],
@@ -50,7 +51,6 @@
       "path": "/packs/journals.db",
       "entity": "JournalEntry",
       "type": "JournalEntry",
-      "module": "scene-packer",
       "private": false
     },
     {
@@ -59,7 +59,6 @@
       "path": "/packs/macros.db",
       "entity": "Macro",
       "type": "Macro",
-      "module": "scene-packer",
       "private": false
     }
   ],
@@ -68,7 +67,7 @@
     "/scripts/wrapped.js"
   ],
   "styles": [
-    "./styles/scene-packer.css"
+    "styles/scene-packer.css"
   ],
   "languages": [
     {
@@ -84,6 +83,5 @@
   "changelog": "https://github.com/League-of-Foundry-Developers/scene-packer/blob/main/CHANGELOG.md",
   "flags": {
     "allowBugReporter": true
-  },
-  "allowBugReporter": true
+  }
 }

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -724,6 +724,7 @@ export default class MoulinetteImporter extends FormApplication {
       return entities;
     }
 
+    const baseURL = await game.moulinette.applications.MoulinetteFileUtil.getBaseURL() || '';
     const adventureFolder = `${this.scenePackerInfo.author}-${this.scenePackerInfo.name}`.slugify({strict: true}) || 'scene-packer-fallback';
     const returnEntities = [];
     console.groupCollapsed(
@@ -773,7 +774,7 @@ export default class MoulinetteImporter extends FormApplication {
 
         const folder = localAsset.substring(0, localAsset.lastIndexOf('/'));
         const filename = asset.split('/').pop();
-        const newAssetLocation = `${folder}/${encodeURIComponent(filename)}`;
+        const newAssetLocation = `${baseURL}${folder}/${encodeURIComponent(filename)}`;
 
         if (needsDownloading) {
           const assetURL = this.packInfo['data/assets/' + asset];


### PR DESCRIPTION
- Fixed issue with the Moulinette importer where asset references would point to the wrong place if you are using an S3 bucket.
  - It was failing to use the S3 bucket URL prefix.