### PR TITLE
v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6.2
+
+- Fixed issue relating to extracting related documents from Journals in v9 and below.
+
 ## v2.6.1
 
 - Fixed "Adventure Converter" to correctly suggest manifest json file updated for v10.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/export-import/related/journals.js
+++ b/scripts/export-import/related/journals.js
@@ -33,6 +33,9 @@ export function ExtractRelatedJournalData(journal) {
 
   for (const path of JournalDataLocations) {
     const content = ResolvePath(path, journal);
+    if (!content) {
+      continue
+    }
     if (path === 'pages') {
       for (const text of content.filter(c => c.type === 'text')) {
         const relations = ExtractUUIDsFromContent(text.content, path);


### PR DESCRIPTION
- Fixed issue relating to extracting related documents from Journals in v9 and below.
  - Code path for v10 support was failing for v9.