### PR TITLE
v2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.6.3
+
+- RollTables imported via the "Import All" method will now change their compendium references to local world documents where possible.
+  - This resolves an issue that was occurring when a RollTable was referencing a Quick Encounter Journal Entry.
+
 ## v2.6.2
 
 - Fixed issue relating to extracting related documents from Journals in v9 and below.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",


### PR DESCRIPTION
- RollTables imported via the "Import All" method will now change their compendium references to local world documents where possible.
  - This resolves an issue that was occurring when a RollTable was referencing a Quick Encounter Journal Entry.