### PR TITLE
v2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.6.4
+
+- Updated the "Relink compendium Entries" macro to better handle Quick Encounter data matching.
+  - It will now fall back to name based matching if it fails to match by ID. If it doesn't find a direct match still, it will put a warning into the console (F12).
+
 ## v2.6.3
 
 - RollTables imported via the "Import All" method will now change their compendium references to local world documents where possible.

--- a/languages/en.json
+++ b/languages/en.json
@@ -256,7 +256,9 @@
         "quick-encounters": {
           "could-not-parse": "Could not parse quick encounter data for journal \"{journal}\". Error: {error}",
           "updating-references": "Changing {count} Quick Encounter references in: \"{journal}\"",
-          "updating-references-console": "Changing {type} {name} reference {oldRef} -> {newRef}"
+          "updating-references-console": "Changing {type} {name} reference {oldRef} -> {newRef}",
+          "missing-actor-reference": "An actor \"{actor}\" was referenced in a Quick Encounter \"{journal}\" but couldn't be found within your world (either is missing, or there are multiple matches by name). This quick encounter will not work correctly in another world. Please rebuild this Quick Encounter, re-export it (and the actor/s), and re-run the \"Relink Journal Entries\" macro.",
+          "missing-journal-reference": "The journal \"{journal}\" couldn't be found within your world (either is missing, or there are multiple matches by name). This quick encounter will not work correctly in another world. Please rebuild this Quick Encounter, re-export it (and the actor/s), and re-run the \"Relink Journal Entries\" macro."
         },
         "monks-enhanced-journal-encounter": {
           "updating-references-console": "Changing Monk's Enhanced Journal Encounter reference in \"{journal}\" {oldRef} -> {newRef}"

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5049,7 +5049,26 @@ export default class ScenePacker {
 
     // Update the journal reference
     if (quickEncounter.journalEntryId && quickEncounter.journalEntryId !== journal.uuid) {
-      const worldJournal = game.journal.get(quickEncounter.journalEntryId);
+      let worldJournal = game.journal.get(quickEncounter.journalEntryId);
+      if (!worldJournal) {
+        // See if we have a single named journal that we can use instead
+        const worldJournals = game.journal.filter(a => a.name === journal.name);
+        if (worldJournals.length === 1) {
+          worldJournal = worldJournals[0];
+        } else {
+          ScenePacker.logType(
+            moduleName,
+            'warn',
+            true,
+            game.i18n.format(
+              'SCENE-PACKER.world-conversion.compendiums.quick-encounters.missing-journal-reference',
+              {
+                journal: journal.name,
+              },
+            ),
+          );
+        }
+      }
       if (worldJournal) {
         // Add a back reference
         if (!dryRun) {
@@ -5075,7 +5094,27 @@ export default class ScenePacker {
     if (quickEncounter.extractedActors) {
       for (let i = 0; i < quickEncounter.extractedActors.length; i++) {
         const actor = quickEncounter.extractedActors[i];
-        const worldActor = game.actors.get(actor.actorID);
+        let worldActor = game.actors.get(actor.actorID);
+        if (!worldActor) {
+          // See if we have a single named actor that we can use instead
+          const worldActors = game.actors.filter(a => a.name === actor.name);
+          if (worldActors.length === 1) {
+            worldActor = worldActors[0];
+          } else {
+            ScenePacker.logType(
+              moduleName,
+              'warn',
+              true,
+              game.i18n.format(
+                'SCENE-PACKER.world-conversion.compendiums.quick-encounters.missing-actor-reference',
+                {
+                  journal: journal.name,
+                  actor: actor.name,
+                },
+              ),
+            );
+          }
+        }
         if (worldActor) {
           const compendiumActor = await instance.FindActorInCompendiums(worldActor, instance.getSearchPacksForType('Actor'));
           if (compendiumActor?.uuid) {


### PR DESCRIPTION
- Updated the "Relink compendium Entries" macro to better handle Quick Encounter data matching.
  - It will now fall back to name based matching if it fails to match by ID. If it doesn't find a direct match still, it will put a warning into the console (F12).