### PR TITLE
v2.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.6.8
+
+- Fixed up several issues with the "Moulinette Exporter" in V10 while maintaining compatibility with V9.
+- Changed default asset timeout to unlimited (was 120 seconds).
+- Fixed journal icons when unpacking a V9 packed world in V10.
+  - Previously they would revert to the default book due to the image path changes.
+
 ## v2.6.7
 
 - Fixed the "Adventure Converter" to correctly handle compendium pack paths presented by Foundry Core during the suggested `module.json` file changes.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/asset-report.js
+++ b/scripts/asset-report.js
@@ -427,7 +427,7 @@ export default class AssetReport extends FormApplication {
    * @return {Promise<Response>}
    */
   static async FetchWithTimeout(resource, options) {
-    let timeout = game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ASSET_TIMEOUT) || 60;
+    let timeout = game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ASSET_TIMEOUT) ?? 60;
     if (options?.timeout) {
       timeout = options.timeout;
     }

--- a/scripts/assets/journal.js
+++ b/scripts/assets/journal.js
@@ -53,6 +53,43 @@ export async function ExtractJournalEntryAssets(journal) {
     }
   }
 
+  if (journalData.pages) {
+    for (const page of journalData.pages) {
+      if (page.type === 'image' && page.src) {
+        await data.AddAsset({
+          id: page.id,
+          key: 'pages',
+          parentID: journal.id,
+          parentType: journal.documentName,
+          documentType: journal.documentName,
+          location: AssetReport.Locations.JournalImage,
+          asset: page.src,
+        });
+      }
+
+      if (page.type === 'text' && page.text?.content) {
+        const doc = new DOMParser().parseFromString(
+          page.text.content,
+          'text/html'
+        );
+        const images = doc.getElementsByTagName('img');
+        for (const image of images) {
+          if (image?.src && !image.src.startsWith('data:')) {
+            await data.AddAsset({
+              id: page.id,
+              key: 'content',
+              parentID: journal.id,
+              parentType: journal.documentName,
+              documentType: journal.documentName,
+              location: AssetReport.Locations.JournalEmbeddedImage,
+              asset: image.src,
+            });
+          }
+        }
+      }
+    }
+  }
+
   data.AddAssetData(await ExtractQuickEncounterAssets(journal));
   data.AddAssetData(await ExtractMonksEnhancedJournalAssets(journal));
 

--- a/scripts/assets/scene.js
+++ b/scripts/assets/scene.js
@@ -31,6 +31,18 @@ export async function ExtractSceneAssets(scene) {
     });
   }
 
+  if (sceneData.background?.src) {
+    await data.AddAsset({
+      id: scene.id,
+      key: 'img',
+      parentID: scene.id,
+      parentType: scene.documentName,
+      documentType: scene.documentName,
+      location: AssetReport.Locations.SceneBackground,
+      asset: sceneData.background.src,
+    });
+  }
+
   if (sceneData.foreground) {
     await data.AddAsset({
       id: scene.id,
@@ -67,7 +79,20 @@ export async function ExtractSceneAssets(scene) {
 
   for (const note of notes) {
     const noteData = CONSTANTS.IsV10orNewer() ? note : note?.data;
-    const icon = noteData?.icon || note?.icon;
+    if (noteData.texture?.src) {
+      await data.AddAsset({
+        id: note.id,
+        key: 'texture.src',
+        parentID: scene.id,
+        parentType: scene.documentName,
+        documentType: note.documentName || 'Note',
+        location: AssetReport.Locations.SceneNoteIcon,
+        asset: noteData.texture.src,
+      });
+      continue;
+    }
+
+    const icon = noteData?.icon ?? note?.icon;
     if (icon) {
       await data.AddAsset({
         id: note.id,
@@ -93,6 +118,17 @@ export async function ExtractSceneAssets(scene) {
         documentType: tile.documentName || 'Tile',
         location: AssetReport.Locations.SceneTileImage,
         asset: img,
+      });
+    }
+    if (tileData.texture?.src) {
+      await data.AddAsset({
+        id: tile.id,
+        key: 'texture.src',
+        parentID: scene.id,
+        parentType: scene.documentName,
+        documentType: tile.documentName || 'Tile',
+        location: AssetReport.Locations.SceneTileImage,
+        asset: tileData.texture.src,
       });
     }
   }
@@ -125,6 +161,17 @@ export async function ExtractSceneAssets(scene) {
         documentType: token.documentName || 'Token',
         location: AssetReport.Locations.SceneTokenImage,
         asset: img,
+      });
+    }
+    if (tokenData.texture?.src) {
+      await data.AddAsset({
+        id: token.id,
+        key: 'texture.src',
+        parentID: scene.id,
+        parentType: scene.documentName,
+        documentType: token.documentName || 'Token',
+        location: AssetReport.Locations.SceneTokenImage,
+        asset: tokenData.texture.src,
       });
     }
   }

--- a/scripts/export-import/compressor.js
+++ b/scripts/export-import/compressor.js
@@ -294,7 +294,7 @@ export class Compressor {
    * @return {Promise<Response>}
    */
   static async FetchWithTimeout(resource, options) {
-    let timeout = game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ASSET_TIMEOUT) || 60;
+    let timeout = game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ASSET_TIMEOUT) ?? 60;
     if (options?.timeout) {
       timeout = options.timeout;
     }

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -285,6 +285,18 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
+        if (CONSTANTS.IsV10orNewer()) {
+          // Loop through the scenes to fix up note icons from v9 to v10 (the paths changed)
+          for (const document of documents) {
+            for (const note of document.notes) {
+              const hasNonDefaultIcon = note.icon && note.icon !== 'icons/svg/book.svg';
+              const hasDefaultTexture = note.texture?.src && note.texture.src === 'icons/svg/book.svg';
+              if (hasDefaultTexture && hasNonDefaultIcon) {
+                note.texture = { src: note.icon };
+              }
+            }
+          }
+        }
         const created = await Scene.createDocuments(documents, {keepId: true});
         for (const id of created.map(s => s.id)) {
           const scene = game.scenes.get(id);

--- a/scripts/export-import/related/journals.js
+++ b/scripts/export-import/related/journals.js
@@ -144,7 +144,9 @@ export function ExtractRelatedEnhancedJournalData(journal) {
     return relatedData;
   }
 
-  const enhancedJournalData = getProperty(journal, 'data.flags.monks-enhanced-journal');
+  const path = 'flags.monks-enhanced-journal';
+  const journalData = CONSTANTS.IsV10orNewer() ? journal : journal.data;
+  const enhancedJournalData = getProperty(journalData, path);
   if (!enhancedJournalData) {
     return relatedData;
   }

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5536,42 +5536,42 @@ Hooks.once('setup', () => {
     scope: 'client',
     config: true,
     type: Number,
-    default: 120,
+    default: 0,
   });
 
   game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_AUTHOR, {
     scope: 'client',
     config: false,
     type: String,
-    default: false,
+    default: '',
   });
 
   game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_DISCORD, {
     scope: 'client',
     config: false,
     type: String,
-    default: false,
+    default: '',
   });
 
   game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_EMAIL, {
     scope: 'client',
     config: false,
     type: String,
-    default: false,
+    default: '',
   });
 
   game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_TAGS, {
     scope: 'client',
     config: false,
     type: Array,
-    default: false,
+    default: [],
   });
 
   game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_THEMES, {
     scope: 'client',
     config: false,
     type: Array,
-    default: false,
+    default: [],
   });
 });
 

--- a/templates/export-import/exporter.hbs
+++ b/templates/export-import/exporter.hbs
@@ -1,20 +1,31 @@
 {{#*inline "folderPartial"}}
-  <li class="directory-item folder flexcol {{#unless folder.expanded}}collapsed{{/unless}}"
-      data-folder-id="{{folder.id}}" data-folder-depth="{{folder.depth}}">
+  {{#if isV9}}
+    <li class="directory-item folder flexcol {{#unless folder.expanded}}collapsed{{/unless}}"
+        data-folder-id="{{folder.id}}" data-folder-depth="{{folder.depth}}">
+  {{else}}
+    <li class="directory-item folder flexcol {{#unless folder.folder.expanded}}collapsed{{/unless}}"
+        data-folder-id="{{folder.folder.id}}" data-folder-depth="{{folder.folder.depth}}">
+  {{/if}}
     <header class="folder-header flexrow" style="background-color: {{folder.data.color}}">
       <h3>
-        <input type="checkbox" data-type="Folder" data-folder-type="{{folder.type}}" value="{{folder.id}}" checked>
-        <i class="fas fa-folder-open fa-fw"></i>{{folder.name}}
+        <input type="checkbox" data-type="Folder" data-folder-type="{{#if isV9}}{{folder.type}}{{else}}{{folder.folder.type}}{{/if}}" value="{{#if isV9}}{{folder.id}}{{else}}{{folder.folder.id}}{{/if}}" checked>
+    <i class="fas fa-folder-open fa-fw"></i>{{#if isV9}}{{folder.name}}{{else}}{{folder.folder.name}}{{/if}}
       </h3>
     </header>
 
     <ol class="subdirectory">
       {{~#each folder.children as |child i|}}
-        {{> folderPartial folder=child user=../user}}
+        {{> folderPartial folder=child user=../user isV9=../isV9}}
       {{/each}}
-      {{#each folder.content}}
-        {{> entityPartial}}
-      {{/each~}}
+      {{#if isV9}}
+        {{#each folder.content}}
+          {{> entityPartial}}
+        {{/each~}}
+      {{else}}
+        {{#each folder.documents}}
+          {{> entityPartial}}
+        {{/each~}}
+      {{/if}}
     </ol>
   </li>
 {{/inline}}
@@ -57,11 +68,17 @@
 
       <ol class="directory-list" data-entity="Scene">
         {{~#each scenes.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each scenes.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each scenes.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each scenes.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -77,11 +94,17 @@
 
       <ol class="directory-list" data-entity="Actor">
         {{~#each actors.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each actors.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each actors.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each actors.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -97,11 +120,17 @@
 
       <ol class="directory-list" data-entity="Item">
         {{~#each items.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each items.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each items.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each items.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -117,11 +146,17 @@
 
       <ol class="directory-list" data-entity="JournalEntry">
         {{~#each journals.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each journals.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each journals.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each journals.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -137,11 +172,17 @@
 
       <ol class="directory-list" data-entity="RollTable">
         {{~#each tables.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each tables.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each tables.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each tables.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -157,11 +198,17 @@
 
       <ol class="directory-list" data-entity="Playlist">
         {{~#each playlists.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each playlists.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each playlists.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each playlists.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -177,11 +224,17 @@
 
       <ol class="directory-list" data-entity="Cards">
         {{~#each cards.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each cards.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each cards.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each cards.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -197,11 +250,17 @@
 
       <ol class="directory-list" data-entity="Macro">
         {{~#each macros.tree.children as |f fi|}}
-          {{> folderPartial folder=f user=../user}}
+          {{> folderPartial folder=f user=../user isV9=../isV9}}
         {{/each}}
-        {{#each macros.tree.content}}
-          {{> entityPartial}}
-        {{/each~}}
+        {{#if isV9}}
+          {{#each macros.tree.content}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{else}}
+          {{#each macros.tree.documents}}
+            {{> entityPartial}}
+          {{/each~}}
+        {{/if}}
       </ol>
     </div>
 
@@ -235,7 +294,11 @@
           <i class="fas fa-question-circle" title="{{localize 'SCENE-PACKER.exporter.options.package-description-help'}}"></i>
         </label>
         <div class="package-description">
-          {{editor content=packageDescription target="packageDescription" button=false editable=true owner=true}}
+          {{#unless isV9}}
+            {{editor packageDescription target="packageDescription" button=false editable=true owner=true}}
+          {{else}}
+            {{editor content=packageDescription target="packageDescription" button=false editable=true owner=true}}
+          {{/unless}}
         </div>
       </div>
       <div class="form-group file-picker">


### PR DESCRIPTION
- Fixed up several issues with the "Moulinette Exporter" in V10 while maintaining compatibility with V9.
- Changed default asset timeout to unlimited (was 120 seconds).
- Fixed journal icons when unpacking a V9 packed world in V10.
  - Previously they would revert to the default book due to the image path changes.