### PR TITLE
v2.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.6.8
+## v2.6.9
 
 - Fixed up several issues with the "Moulinette Exporter" in V10 while maintaining compatibility with V9.
 - Changed default asset timeout to unlimited (was 120 seconds).

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -390,7 +390,15 @@ export default class Exporter extends FormApplication {
       return;
     }
 
-    if (data?.type !== 'JournalEntry' || !data?.id) {
+    if (data?.type !== 'JournalEntry') {
+      return;
+    }
+
+    if (!data?.id && data?.uuid) {
+      data.id = data.uuid.split('.').pop();
+    }
+
+    if (!data?.id) {
       return;
     }
 


### PR DESCRIPTION
- Fixed up several issues with the "Moulinette Exporter" in V10 while maintaining compatibility with V9.
- Changed default asset timeout to unlimited (was 120 seconds).
- Fixed journal icons when unpacking a V9 packed world in V10.
  - Previously they would revert to the default book due to the image path changes.