### PR TITLE
v2.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6.11
+
+- Updated the "Relink compedium Entries" macro to better handle v10.
+  - Now handles Actor.Item and associated "embedded" documents within entities.
 ## v2.6.10
 
 - Updated the "Relink compendium Entries" macro to better handle v10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Updated the "Relink compedium Entries" macro to better handle v10.
   - Now handles Actor.Item and associated "embedded" documents within entities.
+- Updated packing/unpacking of Monk's Active Tile's data to handle the new way it stores cross-scene teleport information.
+
 ## v2.6.10
 
 - Updated the "Relink compendium Entries" macro to better handle v10.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -3696,6 +3696,7 @@ export default class ScenePacker {
                 a?.data?.item?.id ||
                 a?.data?.location?.id ||
                 a?.data?.location?.sceneId ||
+                a?.data?.location?.scene ||
                 a?.data?.rolltableid,
             )
             .map(async (d) => {
@@ -3713,6 +3714,8 @@ export default class ScenePacker {
                 ref = data.macroid.startsWith('Macro.') ? data.macroid : `Macro.${data.macroid}`;
               } else if (data?.location?.sceneId) {
                 ref = data.location.sceneId.startsWith('Scene.') ? data.location.sceneId : `Scene.${data.location.sceneId}`;
+              } else if (data?.location?.scene) {
+                ref = data.location.scene.startsWith('Scene.') ? data.location.scene : `Scene.${data.location.scene}`;
               } else if (data?.location?.id) {
                 ref = data.location.id;
               } else if (data?.rolltableid) {
@@ -3885,6 +3888,23 @@ export default class ScenePacker {
               );
               if (newValue !== actionData.location.sceneId) {
                 actionData.location.sceneId = newValue;
+                changed = true;
+                actionsCount++;
+              }
+            }
+          }
+        }
+        if (actionData?.location?.scene) {
+          originalValue = actionData.location.scene.startsWith('Scene.') ? actionData.location.scene : `Scene.${actionData.location.scene}`;
+          if (extractEntityID(originalValue)) {
+            newEntity = await findNewEntityValue(originalValue, action, tile, compendiumSourceId);
+            if (newEntity) {
+              newValue = actionData.location.scene.replace(
+                extractEntityID(originalValue),
+                newEntity.id
+              );
+              if (newValue !== actionData.location.scene) {
+                actionData.location.scene = newValue;
                 changed = true;
                 actionsCount++;
               }


### PR DESCRIPTION
- Updated the "Relink compedium Entries" macro to better handle v10.
  - Now handles Actor.Item and associated "embedded" documents within entities.
- Updated packing/unpacking of Monk's Active Tile's data to handle the new way it stores cross-scene teleport information.