### PR TITLE
v2.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Documents linked within RollTables now have an additional fallback method for linking.
 - Automated migration of D&D 5e documents will now only occur on a D&D 5e world.
   - Previously it would attempt to apply if any of the loaded packs were configured for D&D 5e.
+- Allow unpacking to continue if the system doesn't match.
+  - An example of this is loading a D&D 5e module into a PF2e world. Actors and Items won't load, but scenes and journals will still work.
 
 ## v2.6.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v2.6.14
 
 - "Asset Report" will now check assets embedded within Adventures.
+- Adventures imported via Moulinette will attempt to migrate the data prior to creating the entries in the world.
+  - In a lot of cases, this will allow packs created in old versions of Foundry VTT to still be imported in newer versions, rather than just throwing errors.
 - Updated the "Relink compendium Entries" macro:
   - Include UUID style references for all document types where available.
 - Documents linked within RollTables now have an additional fallback method for linking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2.6.14
+
+- "Asset Report" will now check assets embedded within Adventures.
+- Updated the "Relink compendium Entries" macro:
+  - Include UUID style references for all document types where available.
+- Documents linked within RollTables now have an additional fallback method for linking.
+- Automated migration of D&D 5e documents will now only occur on a D&D 5e world.
+  - Previously it would attempt to apply if any of the loaded packs were configured for D&D 5e.
+
 ## v2.6.13
 
 - Updated "Asset Report" macro functionality:

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.13",
+  "version": "2.6.14",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/asset-report.js
+++ b/scripts/asset-report.js
@@ -666,6 +666,19 @@ export default class AssetReport extends FormApplication {
       entities.push(...contents.filter(s => s.name !== CONSTANTS.CF_TEMP_ENTITY_NAME));
     }
 
+    // Check for entities in an adventure
+    for (const module of this.moduleToCheck.packs.filter(p => p.type === 'Adventure')) {
+      const pack = game.packs.get(`${this.moduleToCheck.id}.${module.name}`);
+      if (!pack) {
+        continue;
+      }
+      for (const adventure of await pack.getDocuments()) {
+        if (adventure[AssetReport.Sources[type]]?.size) {
+          entities.push(...adventure[AssetReport.Sources[type]].filter(s => s.name !== CONSTANTS.CF_TEMP_ENTITY_NAME));
+        }
+      }
+    }
+
     return entities;
   }
 

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -297,7 +297,9 @@ export default class MoulinetteImporter extends FormApplication {
             }
           }
         }
-        const created = await Scene.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        const created = await Scene.createDocuments(documents.map(d => Scene.fromSource(d).toObject()), { keepId: true });
         for (const id of created.map(s => s.id)) {
           const scene = game.scenes.get(id);
           if (!scene) {
@@ -342,7 +344,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        const created = await Actor.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        const created = await Actor.createDocuments(documents.map(d => Actor.fromSource(d).toObject()), { keepId: true });
 
         // Check for compendium references within the actors and update them to local world references
         console.groupCollapsed(game.i18n.format('SCENE-PACKER.importer.converting-references', {
@@ -407,7 +411,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        const created = await JournalEntry.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        const created = await JournalEntry.createDocuments(documents.map(d => JournalEntry.fromSource(d).toObject()), { keepId: true });
         if (this.scenePackerInfo?.welcome_journal) {
           if (created.find(j => j.id === this.scenePackerInfo.welcome_journal)) {
             didCreateWelcomeJournal = true;
@@ -450,7 +456,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        const created = await Item.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        const created = await Item.createDocuments(documents.map(d => Item.fromSource(d).toObject()), { keepId: true });
 
         // Check for compendium references within the items and update them to local world references
         console.groupCollapsed(game.i18n.format('SCENE-PACKER.importer.converting-references', {
@@ -488,7 +496,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        await Macro.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        await Macro.createDocuments(documents.map(d => Macro.fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -515,7 +525,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        await Playlist.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        await Playlist.createDocuments(documents.map(d => Playlist.fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -542,7 +554,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        await Cards.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        await Cards.createDocuments(documents.map(d => Cards.fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -569,7 +583,9 @@ export default class MoulinetteImporter extends FormApplication {
         if (folderIDs.length) {
           await this.createFolders(folderIDs);
         }
-        const created = await RollTable.createDocuments(documents, {keepId: true});
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        const created = await RollTable.createDocuments(documents.map(d => RollTable.fromSource(d).toObject()), { keepId: true });
 
         // Check for compendium references within the roll tables and update them to local world references
         console.groupCollapsed(game.i18n.format('SCENE-PACKER.importer.converting-references', {
@@ -669,7 +685,9 @@ export default class MoulinetteImporter extends FormApplication {
           if (folderIDs.length) {
             await this.createFolders(folderIDs);
           }
-          await CONFIG[type].documentClass.createDocuments(documents, {keepId: true});
+          // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+          // for older formats to still be parsed in most cases.
+          await CONFIG[type].createDocuments(documents.map(d => CONFIG[type].fromSource(d).toObject()), { keepId: true });
         }
       }
 
@@ -971,7 +989,9 @@ export default class MoulinetteImporter extends FormApplication {
     }
 
     if (createData.length) {
-      await Folder.createDocuments(createData, {keepId: true});
+      // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+      // for older formats to still be parsed in most cases.
+      await Folder.createDocuments(createData.map(d => Folder.fromSource(d).toObject()), { keepId: true });
     }
   }
 

--- a/scripts/migration.js
+++ b/scripts/migration.js
@@ -16,7 +16,7 @@ export default class Migration {
         return;
       }
 
-      if (module.system === 'dnd5e' || module.packs.some(p => p.system === 'dnd5e')) {
+      if (module.system === 'dnd5e' && module.packs.some(p => p.system === 'dnd5e')) {
         // Turn off compatibility warnings while migrating content
         const existingCompatibilityLogMode = CONFIG.compatibility.mode;
         CONFIG.compatibility.mode = CONST.COMPATIBILITY_MODES.SILENT;

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -3479,12 +3479,16 @@ export default class ScenePacker {
 
     if (tokenInfo?.length) {
       // Import tokens that don't yet exist in the world
-      await this.ImportEntities(
-        this.getSearchPacksForType('Actor'),
-        this.findMissingActors(tokenInfo),
-        'actors',
-        showUI,
-      );
+      try {
+        await this.ImportEntities(
+          this.getSearchPacksForType('Actor'),
+          this.findMissingActors(tokenInfo),
+          'actors',
+          showUI,
+        );
+      } catch (err) {
+        console.error(err);
+      }
     }
 
     if (journalInfo?.length) {
@@ -3606,7 +3610,11 @@ export default class ScenePacker {
 
     // Relink the tokens and spawn the pins
     if (tokenInfo?.length) {
-      await this.relinkTokens(scene, tokenInfo, showUI);
+      try {
+        await this.relinkTokens(scene, tokenInfo, showUI);
+      } catch (e) {
+        console.error(e);
+      }
     }
     if (journalInfo?.length) {
       await this.spawnNotes(scene, journalInfo, showUI);

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5102,8 +5102,8 @@ export default class ScenePacker {
         for (let m = 0; m < possibleMatches.length; m++) {
           const possibleMatch = possibleMatches[m];
           const entity = await p.getDocument(possibleMatch._id);
+          let uuid = entity.uuid || undefined;
           if (entity) {
-            let uuid = entity.uuid || undefined;
             if (CONSTANTS.IsV10orNewer() && pageName) {
               // Original reference was to a page, so we need to find the page in the compendium entry
               let page = entity.pages?.find(p => p.name === pageName);
@@ -5123,7 +5123,11 @@ export default class ScenePacker {
               return [{pack: p.collection, ref: possibleMatch._id, uuid}];
             }
           }
-          matches.push({pack: p.collection, ref: possibleMatch._id});
+          const item = {pack: p.collection, ref: possibleMatch._id};
+          if (uuid) {
+            item.uuid = uuid;
+          }
+          matches.push(item);
         }
       }
     }

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -4694,7 +4694,10 @@ export default class ScenePacker {
                 continue;
               }
               let existingName = CONSTANTS.IsV10orNewer() ? result?.text : result?.data?.text;
-              const existingEntry = game.collections.get(collection)?.get(resultId);
+              let existingEntry = game.collections.get(collection)?.get(resultId);
+              if (!existingEntry && existingName) {
+                existingEntry = game.collections.get(collection)?.getName(existingName);
+              }
               if (existingEntry?.name) {
                 existingName = existingEntry.name;
               }


### PR DESCRIPTION
- "Asset Report" will now check assets embedded within Adventures.
- Adventures imported via Moulinette will attempt to migrate the data prior to creating the entries in the world.
  - In a lot of cases, this will allow packs created in old versions of Foundry VTT to still be imported in newer versions, rather than just throwing errors.
- Updated the "Relink compendium Entries" macro:
  - Include UUID style references for all document types where available.
- Documents linked within RollTables now have an additional fallback method for linking.
- Automated migration of D&D 5e documents will now only occur on a D&D 5e world.
  - Previously it would attempt to apply if any of the loaded packs were configured for D&D 5e.
- Allow unpacking to continue if the system doesn't match.
  - An example of this is loading a D&D 5e module into a PF2e world. Actors and Items won't load, but scenes and journals will still work.