### PR TITLE
v2.6.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6.15
+
+- Automated migration of D&D 5e documents will now apply if the module only specifies the system for individual packs, rather than the overall module.
+
 ## v2.6.14
 
 - "Asset Report" will now check assets embedded within Adventures.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.14",
+  "version": "2.6.15",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/migration.js
+++ b/scripts/migration.js
@@ -16,7 +16,7 @@ export default class Migration {
         return;
       }
 
-      if (module.system === 'dnd5e' && module.packs.some(p => p.system === 'dnd5e')) {
+      if (game.system?.id === 'dnd5e' && (module.system === 'dnd5e' || module.packs.some(p => p.system === 'dnd5e'))) {
         // Turn off compatibility warnings while migrating content
         const existingCompatibilityLogMode = CONFIG.compatibility.mode;
         CONFIG.compatibility.mode = CONST.COMPATIBILITY_MODES.SILENT;


### PR DESCRIPTION
- Automated migration of D&D 5e documents will now apply if the module only specifies the system for individual packs, rather than the overall module.