### PR TITLE
v2.6.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.6.16
 
 - Mark Scene Packer as compatible with v11 of Foundry.
+- Fixed Moulinette importer failing when importing a Single Scene from a pack.
 
 ## v2.6.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6.16
+
+- Mark Scene Packer as compatible with v11 of Foundry.
+
 ## v2.6.15
 
 - Automated migration of D&D 5e documents will now apply if the module only specifies the system for individual packs, rather than the overall module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Mark Scene Packer as compatible with v11 of Foundry.
 - Fixed Moulinette importer failing when importing a Single Scene from a pack.
+- Maintain "Sort" value of documents being exported to a compendium via the Compendium Folders module.
 
 ## v2.6.15
 

--- a/module.json
+++ b/module.json
@@ -3,15 +3,15 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.6.15",
+  "version": "2.6.16",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "10",
+  "compatibleCoreVersion": "11",
   "compatibility": {
     "minimum": "0.8.6",
-    "verified": "10",
-    "maximum": "10"
+    "verified": "11",
+    "maximum": "11"
   },
   "author": "Blair McMillan",
   "authors": [

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -287,6 +287,24 @@ export const CONSTANTS = Object.freeze({
   IsV10(version = this.Version()) {
     return this.IsV10orNewer(version) && isNewerVersion('11', version);
   },
+
+  /**
+   * Returns whether the version is at least V11
+   * @param {string} version - The version to test. Defaults to the current game instance version.
+   * @return {boolean}
+   */
+  IsV11orNewer(version = this.Version()) {
+    return version === '11.0' || isNewerVersion(version, '11');
+  },
+
+  /**
+   * Returns whether the version is V11
+   * @param {string} version - The version to test. Defaults to the current game instance version.
+   * @return {boolean}
+   */
+  IsV11(version = this.Version()) {
+    return this.IsV11orNewer(version) && isNewerVersion('11', version);
+  },
 });
 
 /**

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -687,7 +687,7 @@ export default class MoulinetteImporter extends FormApplication {
           }
           // Run via the .fromSource method as that operates in a non-strict validation format, allowing
           // for older formats to still be parsed in most cases.
-          await CONFIG[type].createDocuments(documents.map(d => CONFIG[type].fromSource(d).toObject()), { keepId: true });
+          await CONFIG[type].documentClass.createDocuments(documents.map(d => CONFIG[type].documentClass.fromSource(d).toObject()), { keepId: true });
         }
       }
 

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -1,7 +1,7 @@
 import AdventureConverter from './adventure-converter/adventure-converter.js';
 import AssetReport from './asset-report.js';
-import {Compressor} from './export-import/compressor.js';
-import {CONSTANTS} from './constants.js';
+import { Compressor } from './export-import/compressor.js';
+import { CONSTANTS } from './constants.js';
 import Exporter from './export-import/exporter.js';
 import Hash from './hash.js';
 import Migration from './migration.js';

--- a/scripts/wrapped.js
+++ b/scripts/wrapped.js
@@ -12,7 +12,23 @@ Hooks.once('setup', function () {
       'scene-packer',
       `${item}.prototype.toCompendium`,
       function (wrapped, ...args) {
-        // const [ pack ] = args;
+        // const [ pack, options={} ] = args;
+
+        // Keep sort orders when exporting to compendium via Compendium Folders
+        if (typeof args === 'undefined') {
+          args = [];
+        }
+        // args[0] has a pack value when dragging a document to a compendium, and also when
+        // exporting via the default export process, so we can skip these cases.
+        if (typeof args[0] === 'undefined') {
+          if (typeof args[1] === 'undefined') {
+            args[1] = {};
+          }
+          if (typeof args[1].clearSort === 'undefined') {
+            args[1].clearSort = false;
+          }
+        }
+
         let data = wrapped.bind(this)(...args);
 
         const newFlags = {};


### PR DESCRIPTION
- Mark Scene Packer as compatible with v11 of Foundry.
- Fixed Moulinette importer failing when importing a Single Scene from a pack.
- Maintain "Sort" value of documents being exported to a compendium via the Compendium Folders module.