### PR TITLE
v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.7.1
+
+- Fix issue where the Moulinette module was incorrectly required for handling a direct Zip upload.
+- Added check to see whether the Zip file is too large to process by the browser.
+  - This value is approximately 2GB on Chrome and approximately 4GB on Firefox. 
+
 ## v2.7.0
 
 - Added support for importing Moulinette Zip files from the Settings window.

--- a/languages/en.json
+++ b/languages/en.json
@@ -336,7 +336,9 @@
       "description2": "The importer will import the entire pack from the ZIP. If you are wanting just a single scene, use Moulinette instead.",
       "error-unzip": "There was an error unzipping the file \"{name}\". Please ask for assistance on the Scene Packer Discord server.",
       "ensure-assets": "Ensuring {count} assets exist.",
-      "ensure-asset-error": "Error creating asset: {error}"
+      "ensure-asset-error": "Error creating asset: {error}",
+      "error-read": "There was an error reading the file \"{name}\". Please ask for assistance on the Scene Packer Discord server.",
+      "zip-too-large": "The ZIP file is too large to import. For maximum compatibility, ZIP files should be less than 2GB. Please ask for assistance on the Scene Packer Discord server."
     },
     "exporter": {
       "name": "Export to Moulinette",

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",


### PR DESCRIPTION
- Fix issue where the Moulinette module was incorrectly required for handling a direct Zip upload.
- Added check to see whether the Zip file is too large to process by the browser.
  - This value is approximately 2GB on Chrome and approximately 4GB on Firefox.