### PR TITLE
v2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7.3
+
+- Maintain the sort order when importing all documents from the welcome dialog.
+  - Right-clicking on a compendium and choosing "Import All" will still use the default Foundry VTT functionality, which removes the sort order. 
+
 ## v2.7.2
 
 - Fixed Moulinette exporter not working on v11.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -532,7 +532,7 @@ export default class ScenePacker {
           // Append the entities found in this pack to the growing list to import
           createData = createData.concat(
             packContent.map(c => {
-              let cData = collection.fromCompendium(c);
+              let cData = collection.fromCompendium(c, {clearSort: false, keepId: true});
               cData._id = c.id; // Preserve the original ID
 
               const newFlags = {};
@@ -2673,7 +2673,7 @@ export default class ScenePacker {
         // Append the entities found in this pack to the growing list to import
         createData = createData.concat(
           content.map((c) => {
-            const cData = collection.fromCompendium(c);
+            const cData = collection.fromCompendium(c, {clearSort: false, keepId: true});
             // Utilise the folder structure as defined by the Compendium Folder if it exists, otherwise
             // fall back to the default folder.
             const cfPath = cData.flags?.cf?.path;
@@ -3476,7 +3476,7 @@ export default class ScenePacker {
       update.sort = entityData.flags.cf.sort;
     }
 
-    return await collection.importFromCompendium(game.packs.get(entity.compendium.collection), entity.id, update, {keepId: true});
+    return await collection.importFromCompendium(game.packs.get(entity.compendium.collection), entity.id, update, {clearSort: false, keepId: true});
   }
 
   /**


### PR DESCRIPTION
- Maintain the sort order when importing all documents from the welcome dialog.
  - Right-clicking on a compendium and choosing "Import All" will still use the default Foundry VTT functionality, which removes the sort order. 