### PR TITLE
v2.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.7.7
+
+- Moulinette Exporter changes:
+  - now defaults to nothing selected, rather than everything in the world selected for export.
+  - now remembers the previously entered URL and Journal.
+  - selecting a single entity will now automatically select any parent folders.
+
 ## v2.7.6
 
 - "Relink compendium entries" macro will no longer remove compendiums from their folders.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -170,6 +170,16 @@ export const CONSTANTS = Object.freeze({
   SETTING_EXPORT_TO_MOULINETTE_THEMES: 'exportToMoulinetteThemes',
 
   /**
+   * The setting key for tracking previously used URL in the Moulinette Exporter.
+   */
+  SETTING_EXPORT_TO_MOULINETTE_URL: 'exportToMoulinetteURL',
+
+  /**
+   * The setting key for tracking previously used Welcome Journal in the Moulinette Exporter.
+   */
+  SETTING_EXPORT_TO_MOULINETTE_WELCOME_JOURNAL: 'exportToMoulinetteWelcomeJournal',
+
+  /**
    * The setting key for triggering the Importer class.
    */
   SETTING_IMPORT_FROM_ZIP: 'importFromZip',

--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -288,17 +288,7 @@ export default class Exporter extends FormApplication {
       supportsCards: this.supportsCards,
       cards: this.Cards,
       macros: this.Macro,
-      summary: game.i18n.format('SCENE-PACKER.exporter.selected-count', {
-        count:
-          this.Scene.documents.size +
-          this.Actor.documents.size +
-          this.Item.documents.size +
-          this.Cards.documents.size +
-          this.JournalEntry.documents.size +
-          this.RollTable.documents.size +
-          this.Playlist.documents.size +
-          this.Macro.documents.size,
-      }),
+      summary: game.i18n.format('SCENE-PACKER.exporter.selected-count', {count: 0}),
       complete: this.complete,
       packageName: worldData.title,
       packageAuthor: game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_AUTHOR) || '',
@@ -307,6 +297,8 @@ export default class Exporter extends FormApplication {
       packageDescription: worldData.description,
       packageDiscord: game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_DISCORD) || '',
       packageEmail: game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_EMAIL) || '',
+      packageUrl: game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_URL) || '',
+      packageWelcomeJournal: game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_WELCOME_JOURNAL) || '',
       adventureSystem: game.system.id,
       adventureCategoryOptions: this.adventureCategoryOptions,
       adventureThemeSuggestions: Array.from(this.adventureThemeSuggestions),
@@ -527,8 +519,12 @@ export default class Exporter extends FormApplication {
   _onClickCheckbox(event) {
     event.stopPropagation();
     const element = event.currentTarget;
+    const isBeingTicked = $(element).prop('checked');
     let $input = $(element).closest('li').find('input[type="checkbox"]');
-    $input.prop('checked', $(element).prop('checked'));
+    $input.prop('checked', isBeingTicked);
+    if (isBeingTicked) {
+      $input.parents('.directory-item.folder').children('header').find('input[type="checkbox"]').prop('checked', isBeingTicked);
+    }
     this._updateCounts();
   }
 
@@ -543,8 +539,13 @@ export default class Exporter extends FormApplication {
       return;
     }
     event.preventDefault();
-    const $input = $(event.currentTarget).find('input[type="checkbox"]');
-    $input.prop('checked', !$input.prop('checked'));
+    const element = event.currentTarget;
+    const $input = $(element).find('input[type="checkbox"]');
+    const isBeingTicked = !$input.prop('checked');
+    $input.prop('checked', isBeingTicked);
+    if (isBeingTicked) {
+      $input.parents('.directory-item.folder').children('header').find('input[type="checkbox"]').prop('checked', isBeingTicked);
+    }
     this._updateCounts();
   }
 
@@ -553,9 +554,7 @@ export default class Exporter extends FormApplication {
    */
   _updateCounts() {
     let scenePackerExporter = $('#scene-packer-exporter');
-    this.selected = scenePackerExporter
-      .find('input[type="checkbox"]:checked')
-      .filter((i, e) => e.dataset.type !== 'Folder');
+    this.selected = scenePackerExporter.find('div.tab:not([data-tab=options]) input[type="checkbox"]:checked');
     scenePackerExporter
       .find('footer p.summary')
       .text(

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5870,6 +5870,20 @@ Hooks.once('setup', () => {
     type: Array,
     default: [],
   });
+
+  game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_URL, {
+    scope: 'client',
+    config: false,
+    type: String,
+    default: '',
+  });
+
+  game.settings.register(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_EXPORT_TO_MOULINETTE_WELCOME_JOURNAL, {
+    scope: 'client',
+    config: false,
+    type: String,
+    default: '',
+  });
 });
 
 /**

--- a/templates/export-import/exporter.hbs
+++ b/templates/export-import/exporter.hbs
@@ -8,7 +8,7 @@
   {{/if}}
     <header class="folder-header flexrow" style="background-color: {{folder.data.color}}">
       <h3>
-        <input type="checkbox" data-type="Folder" data-folder-type="{{#if isV9}}{{folder.type}}{{else}}{{folder.folder.type}}{{/if}}" value="{{#if isV9}}{{folder.id}}{{else}}{{folder.folder.id}}{{/if}}" checked>
+        <input type="checkbox" data-type="Folder" data-folder-type="{{#if isV9}}{{folder.type}}{{else}}{{folder.folder.type}}{{/if}}" value="{{#if isV9}}{{folder.id}}{{else}}{{folder.folder.id}}{{/if}}">
     <i class="fas fa-folder-open fa-fw"></i>{{#if isV9}}{{folder.name}}{{else}}{{folder.folder.name}}{{/if}}
       </h3>
     </header>
@@ -33,7 +33,7 @@
 {{#*inline "entityPartial"}}
   <li class="directory-item entity" data-entity-id="{{this.id}}">
     <label class="flexrow">
-      <input type="checkbox" data-type="{{this.documentName}}" name="entity.{{this.documentName}}.{{this.id}}" value="{{this.id}}" checked>
+      <input type="checkbox" data-type="{{this.documentName}}" name="entity.{{this.documentName}}.{{this.id}}" value="{{this.id}}">
       {{#if this.thumbnail}}<img class="profile actor-profile" title="{{this.name}}" data-src="{{this.thumbnail}}" style="margin-right: 5px;">
       {{else if this.img}}<img class="profile actor-profile" title="{{this.name}}" data-src="{{this.img}}" style="margin-right: 5px;">{{/if}}
       <h4 class="entity-name"><a class="entity-link content-link" data-type="{{this.documentName}}" data-entity="{{this.documentName}}" data-id="{{this.id}}">{{this.name}}</a></h4>
@@ -61,7 +61,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.scenes'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -87,7 +87,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.actors'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -113,7 +113,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.items'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -139,7 +139,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.journals'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -165,7 +165,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.tables'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -191,7 +191,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.playlists'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -217,7 +217,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.cards'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up"></i></a>
         </div>
       </header>
@@ -243,7 +243,7 @@
         <div class="header-search flexrow">
           <i class="fas fa-search"></i>
           <input type="text" name="search" value="" placeholder="{{localize 'SCENE-PACKER.exporter.search.macros'}}" autocomplete="off"/>
-          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="1"><i class="fas fa-check-square"></i></a>
+          <a class="header-control toggle-all" title="{{localize 'SCENE-PACKER.exporter.toggle-checkboxes'}}" data-state="0"><i class="fas fa-check-square"></i></a>
           <a class="header-control collapse-all" title="{{localize 'FOLDER.Collapse'}}"><i class="fas fa-sort-amount-up fa-fw"></i></a>
         </div>
       </header>
@@ -330,14 +330,14 @@
           <b>{{localize 'SCENE-PACKER.exporter.options.external-link'}}</b>
           <i class="fas fa-question-circle" title="{{localize 'SCENE-PACKER.exporter.options.external-link-help'}}"></i>
         </label>
-        <input type="text" id="SP-export-externalLink" name="externalLink" value="" placeholder="https://patreon.com">
+        <input type="text" id="SP-export-externalLink" name="externalLink" value="{{packageUrl}}" placeholder="https://patreon.com">
       </div>
       <div class="form-group">
         <label for="SP-export-welcomeJournal">
           <b>{{localize 'SCENE-PACKER.exporter.options.welcome-journal'}}</b>
           <i class="fas fa-question-circle" title="{{localize 'SCENE-PACKER.exporter.options.welcome-journal-help'}}"></i>
         </label>
-        <input type="text" id="SP-export-welcomeJournal" name="welcomeJournal" value="" placeholder="{{localize 'SCENE-PACKER.exporter.options.welcome-journal-drop-text'}}" autocomplete="off">
+        <input type="text" id="SP-export-welcomeJournal" name="welcomeJournal" value="{{packageWelcomeJournal}}" placeholder="{{localize 'SCENE-PACKER.exporter.options.welcome-journal-drop-text'}}" autocomplete="off">
       </div>
       <div class="form-group">
         <div>


### PR DESCRIPTION
- Moulinette Exporter changes:
  - now defaults to nothing selected, rather than everything in the world selected for export.
  - now remembers the previously entered URL and Journal.
  - selecting a single entity will now automatically select any parent folders.