### PR TITLE
Workaround/fix for ActiveTiles RollTables change in structure

### DIFF
--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -3971,22 +3971,39 @@ export default class ScenePacker {
             }
           }
         }
-        if (actionData?.rolltableid) {
-          originalValue = actionData.rolltableid.startsWith('RollTable.') ? actionData.rolltableid : `RollTable.${actionData.rolltableid}`;
+
+        if (actionData?.rolltableid?.id) {
+          originalValue = actionData.rolltableid.id.startsWith('RollTable.') ? actionData.rolltableid.id : `RollTable.${actionData.rolltableid.id}`;
           if (extractEntityID(originalValue)) {
-          newEntity = await findNewEntityValue(originalValue, action, tile, compendiumSourceId);
-          if (newEntity) {
-            newValue = actionData.rolltableid.replace(
-              extractEntityID(originalValue),
-              newEntity.id
-            );
-            if (newValue !== actionData.rolltableid) {
-              actionData.rolltableid = newValue;
-              changed = true;
-              actionsCount++;
+            newEntity = await findNewEntityValue(originalValue, action, tile, compendiumSourceId);
+            if (newEntity) {
+              newValue = actionData.rolltableid.id.replace(
+                extractEntityID(originalValue),
+                newEntity.id
+              );
+              if (newValue !== actionData.rolltableid.id) {
+                actionData.rolltableid.id = newValue;
+                changed = true;
+                actionsCount++;
+              }
             }
           }
-        }
+        } else if (actionData?.rolltableid) {
+          originalValue = actionData.rolltableid.startsWith('RollTable.') ? actionData.rolltableid : `RollTable.${actionData.rolltableid}`;
+          if (extractEntityID(originalValue)) {
+            newEntity = await findNewEntityValue(originalValue, action, tile, compendiumSourceId);
+            if (newEntity) {
+              newValue = actionData.rolltableid.replace(
+                extractEntityID(originalValue),
+                newEntity.id
+              );
+              if (newValue !== actionData.rolltableid) {
+                actionData.rolltableid = newValue;
+                changed = true;
+                actionsCount++;
+              }
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Fixing #136

Adds a case for handling RollTable actions exported in monks-active-tiles where the rolltableid is an object, rather than a string.

Leaves the old string-case in for older exports, and people using older version of monks-active-tiles.

I am new to the codebase, so there's probably a better pattern for this, but this unblocked my work.
