### PR TITLE
v2.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7.9
+
+- Updated the "Relink compendium Entries" macro:
+  - Fixed issue where links that included anchors would be skipped. Thanks JonnyGabble on Discord for the report.
+
 ## v2.7.8
 
 - Adjustments to handle new data structures expected by [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles).

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5079,7 +5079,7 @@ export default class ScenePacker {
         newRef: newRef,
         pack: pack.collection,
         journalEntryId: entry._id,
-        journalAnchorLink: anchor ? anchor : '',
+        journalAnchorLink: anchor ? `#${anchor}` : '',
       });
     }
 
@@ -5107,7 +5107,7 @@ export default class ScenePacker {
         const prefix = CONSTANTS.IsV10orNewer() ? '@UUID[' : '@Compendium[';
         const newReference = change.newRef[0];
         if (!newReference.uuid) {
-          newReference.uuid = `${newReference.pack}.${newReference.ref}${change.journalAnchorLink}`;
+          newReference.uuid = `${newReference.pack}.${newReference.ref}`;
         }
         if (!CONSTANTS.IsV10orNewer() && newReference.uuid.startsWith('Compendium.')) {
           newReference.uuid = newReference.uuid.replace('Compendium.', '');
@@ -5132,9 +5132,10 @@ export default class ScenePacker {
           `@${change.type}\\[${change.oldRef}${change.journalAnchorLink}\\]\\{`,
           'g',
         );
+        const replacement = change.journalAnchorLink ? `${prefix}${newReference.uuid}${change.journalAnchorLink}]{` : `${prefix}${newReference.uuid}]{`;
         newContent = newContent.replace(
           regex,
-          `${prefix}${newReference.uuid}]{`,
+          replacement,
         );
       }
 


### PR DESCRIPTION
- Updated the "Relink compendium Entries" macro:
  - Fixed issue where links that included anchors would be skipped. Thanks JonnyGabble on Discord for the report.