### PR TITLE
v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.8.0
+- Added support for importing partial playlists via the Moulinette importer (and associated zip importer).
+  - Allows creators to export individual sounds from a playlist and have it be merged into an existing playlist on import.
+  - This can be helpful for a creator who wants to release individual sounds, but have a single playlist across their module releases.
+
 ## v2.7.15
 - Added a button in the settings to more easily re-prompt for a module's automatic importer.
   - This functionality always existed via a macro. This button just makes it easier to find.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.7.15",
+  "version": "2.8.0",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/assets/playlist.js
+++ b/scripts/assets/playlist.js
@@ -5,9 +5,10 @@ import { CONSTANTS } from '../constants.js';
 /**
  * Extract assets from the given playlist
  * @param {Playlist|ClientDocumentMixin} playlist - The playlist to extract assets from.
+ * @param {Set<string>} selectedSounds - The sounds in the playlist.
  * @return {AssetData}
  */
-export async function ExtractPlaylistAssets(playlist) {
+export async function ExtractPlaylistAssets(playlist, selectedSounds) {
   const data = new AssetData({
     id: playlist?.id || '',
     name: playlist?.name || '',
@@ -18,11 +19,16 @@ export async function ExtractPlaylistAssets(playlist) {
     return data;
   }
 
-  const sounds = [];
+  let sounds = [];
 
   const playlistData = CONSTANTS.IsV10orNewer() ? playlist : playlist.data;
   if (playlistData.sounds?.size) {
     sounds.push(...Array.from(playlistData.sounds.values()));
+  }
+
+  if (selectedSounds.size) {
+    // Remove sounds that are not selected
+    sounds = sounds.filter(sound => selectedSounds.has(sound.id));
   }
 
   for (const sound of sounds) {

--- a/scripts/export-import/exporter-progress.js
+++ b/scripts/export-import/exporter-progress.js
@@ -219,9 +219,9 @@ export default class ExporterProgress extends FormApplication {
             }
 
             const hash = Hash.SHA1(document);
-            setProperty(document, 'flags.scene-packer.hash', hash);
-            setProperty(document, 'flags.scene-packer.moulinette-adventure-name', this.packageName);
-            setProperty(document, 'flags.scene-packer.moulinette-adventure-version', this.exporterData?.version || '1.0.0');
+            foundry.utils.setProperty(document, 'flags.scene-packer.hash', hash);
+            foundry.utils.setProperty(document, 'flags.scene-packer.moulinette-adventure-name', this.packageName);
+            foundry.utils.setProperty(document, 'flags.scene-packer.moulinette-adventure-version', this.exporterData?.version || '1.0.0');
           }
           dataZip.AddToZip(out, `data/${type}.json`);
           updateTotalSize({

--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -527,6 +527,24 @@ export default class Exporter extends FormApplication {
     if (isBeingTicked) {
       $input.parents('.directory-item.folder').children('header').find('input[type="checkbox"]').prop('checked', isBeingTicked);
     }
+
+    const playlistSounds = $(element).closest('ul.playlist-sounds');
+    if (playlistSounds.length) {
+      // Allow playlist sounds to be individually selected within a playlist
+      const checkboxes = playlistSounds.find('input[type="checkbox"]');
+      const numChecked = checkboxes.filter(':checked').length;
+      const allChecked = checkboxes.length === numChecked;
+      if (numChecked > 0 && !allChecked) {
+        // Indeterminate state
+        playlistSounds.siblings('label').find('input[type="checkbox"]').prop('checked', false).prop('indeterminate', true);
+      } else if (allChecked) {
+        // All checked
+        playlistSounds.siblings('label').find('input[type="checkbox"]').prop('checked', true).prop('indeterminate', false);
+      } else {
+        // None checked
+        playlistSounds.siblings('label').find('input[type="checkbox"]').prop('checked', false).prop('indeterminate', false);
+      }
+    }
     this._updateCounts();
   }
 
@@ -540,6 +558,13 @@ export default class Exporter extends FormApplication {
       // Clicked a direct link
       return;
     }
+
+    const playlistSounds = $(event.target).closest('ul.playlist-sounds');
+    if (playlistSounds.length) {
+      // Bubble the event up to the individual checkbox
+      return;
+    }
+
     event.preventDefault();
     const element = event.currentTarget;
     const $input = $(element).find('input[type="checkbox"]');

--- a/scripts/export-import/zip-importer.js
+++ b/scripts/export-import/zip-importer.js
@@ -437,15 +437,48 @@ export default class ZipImporter extends FormApplication {
           count: playlistData.length,
         })}</p>`,
       });
-      const documents = await this.ensureAssets(playlistData, assetMap, assetData);
+      let documents = await this.ensureAssets(playlistData, assetMap, assetData);
       const folderIDs = documents.map(d => d.folder);
       if (folderIDs.length) {
         await MoulinetteImporter.CreateFolders(folderIDs, this.folderData);
       }
-      // Run via the .fromSource method as that operates in a non-strict validation format, allowing
-      // for older formats to still be parsed in most cases.
-      await Playlist.createDocuments(documents.map(d => Playlist.fromSource(d)
-        .toObject()), { keepId: true });
+      // Playlists might need to have individual sounds merged
+      const existingDocuments = documents.filter(d => game[Playlist.collectionName].has(d._id));
+      for (const d of existingDocuments) {
+        const existingPlaylist = game[Playlist.collectionName].get(d._id);
+        if (!existingPlaylist) {
+          continue;
+        }
+        const playlistData = existingPlaylist.toJSON();
+        const sounds = playlistData.sounds || [];
+        const newPlaylistData = Playlist.fromSource(d).toObject();
+        const newSounds = [];
+        let hasUpdates = false;
+        for (const sound of (newPlaylistData.sounds || [])) {
+          const i = sounds.findIndex(s => s._id === sound._id);
+          if (i !== -1) {
+            sounds[i] = sound;
+            hasUpdates = true;
+            continue;
+          }
+          newSounds.push(sound);
+        }
+
+        if (hasUpdates) {
+          await existingPlaylist.updateEmbeddedDocuments('PlaylistSound', sounds);
+        }
+        if (newSounds.length) {
+          await existingPlaylist.createEmbeddedDocuments('PlaylistSound', newSounds);
+        }
+      }
+
+      documents = documents.filter(d => !existingDocuments.some(e => e._id === d._id));
+      if (documents.length) {
+        // Run via the .fromSource method as that operates in a non-strict validation format, allowing
+        // for older formats to still be parsed in most cases.
+        await Playlist.createDocuments(documents.map(d => Playlist.fromSource(d)
+          .toObject()), { keepId: true });
+      }
     }
 
     if (cardData.length) {
@@ -829,7 +862,28 @@ export default class ZipImporter extends FormApplication {
    * @returns {Document[]}
    */
   missingDataOnly(data, collection) {
-    return data.filter(a => collection && !collection.has(a._id));
+     try {
+      return data.filter(a => {
+        if (!collection.has(a._id)) {
+          return true;
+        }
+
+        if (collection.documentName === 'Playlist') {
+          const playlist = collection.get(a._id);
+          const sounds = playlist?.sounds;
+          if (sounds?.size) {
+            // Include the playlist if any of the sounds aren't in the collection's playlist sounds.
+            return a.sounds.map(s => s._id).some(id => !sounds.has(id));
+          }
+        }
+
+        return false;
+      });
+    } catch (err) {
+      console.error(err);
+      // Fallback to returning all data if there is an error
+      return data;
+    }
   }
 
   /**

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -4067,7 +4067,7 @@ export default class ScenePacker {
         const update = {
           _id: tile.id || tile._id,
         };
-        setProperty(update, 'flags.monks-active-tiles.actions', actions);
+        foundry.utils.setProperty(update, 'flags.monks-active-tiles.actions', actions);
         updates.push(update);
       }
     }
@@ -4491,7 +4491,7 @@ export default class ScenePacker {
         });
 
         let newFlags = {};
-        setProperty(newFlags, 'flags.quick-encounters.quickEncounter', JSON.stringify(quickEncounter));
+        foundry.utils.setProperty(newFlags, 'flags.quick-encounters.quickEncounter', JSON.stringify(quickEncounter));
         await journal.update(newFlags);
       }
     }
@@ -5535,8 +5535,8 @@ export default class ScenePacker {
             continue;
           }
 
-          setProperty(savedTileData, 'flags.scene-packer.SPTileData', [spTile]);
-          setProperty(savedTileData, 'flags.scene-packer.source-module', instance.GetModuleName());
+          foundry.utils.setProperty(savedTileData, 'flags.scene-packer.SPTileData', [spTile]);
+          foundry.utils.setProperty(savedTileData, 'flags.scene-packer.source-module', instance.GetModuleName());
         }
       }
       updates.push({
@@ -5571,7 +5571,7 @@ export default class ScenePacker {
 
       if (!dryRun) {
         let newFlags = {};
-        setProperty(newFlags, 'flags.quick-encounters.quickEncounter', JSON.stringify(quickEncounter));
+        foundry.utils.setProperty(newFlags, 'flags.quick-encounters.quickEncounter', JSON.stringify(quickEncounter));
         await journal.update(newFlags);
       }
     }

--- a/styles/scene-packer.css
+++ b/styles/scene-packer.css
@@ -251,3 +251,12 @@
 .sp-welcome-journal .sp-footer hr {
   width: 100%;
 }
+#scene-packer-exporter li.folder > .folder-header {
+  text-shadow: none;
+}
+#scene-packer-exporter .directory .directory-item {
+  line-height: normal;
+}
+#scene-packer-exporter .directory .directory-list input[type="checkbox"] {
+  vertical-align: middle;
+}

--- a/templates/export-import/exporter.hbs
+++ b/templates/export-import/exporter.hbs
@@ -31,13 +31,25 @@
 {{/inline}}
 
 {{#*inline "entityPartial"}}
-  <li class="directory-item entity" data-entity-id="{{this.id}}">
+  <li class="directory-item entity flexcol" data-entity-id="{{this.id}}">
     <label class="flexrow">
       <input type="checkbox" data-type="{{this.documentName}}" name="entity.{{this.documentName}}.{{this.id}}" value="{{this.id}}">
       {{#if this.thumbnail}}<img class="profile actor-profile" title="{{this.name}}" data-src="{{this.thumbnail}}" style="margin-right: 5px;">
       {{else if this.img}}<img class="profile actor-profile" title="{{this.name}}" data-src="{{this.img}}" style="margin-right: 5px;">{{/if}}
       <h4 class="entity-name"><a class="entity-link content-link" data-type="{{this.documentName}}" data-entity="{{this.documentName}}" data-id="{{this.id}}">{{this.name}}</a></h4>
     </label>
+    {{#if (eq this.documentName "Playlist")}}
+      <ul class="playlist-sounds">
+      {{#each this.sounds}}
+        <li class="playlist-sound">
+          <label>
+            <input type="checkbox" data-type="{{this.documentName}}" name="entity.{{this.documentName}}.{{this.id}}" value="{{this.id}}">
+            {{this.name}}
+          </label>
+        </li>
+      {{/each}}
+      </ul>
+    {{/if}}
   </li>
 {{/inline}}
 


### PR DESCRIPTION
- Added support for importing partial playlists via the Moulinette importer (and associated zip importer).
  - Allows creators to export individual sounds from a playlist and have it be merged into an existing playlist on import.
  - This can be helpful for a creator who wants to release individual sounds, but have a single playlist across their module releases.