### PR TITLE
v2.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8.8
+
+- Fixed the fix from v2.8.7 that broke "right clicking" on Scenes in Foundry VTT v12 and below.
+
 ## v2.8.7
 
 - Fixed the "right click" context menus on Scenes not working correctly in Foundry VTT v13.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -5820,6 +5820,7 @@ Hooks.once('setup', () => {
           name: game.i18n.localize('SCENE-PACKER.scene-context.pack.title'),
           icon: '<i class="fas fa-scroll"></i>',
           condition: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             let instance = ScenePacker.GetInstanceForScene(scene);
@@ -5831,6 +5832,7 @@ Hooks.once('setup', () => {
             return game.user.isGM && game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ENABLE_CONTEXT_MENU);
           },
           callback: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             let instance = ScenePacker.GetInstanceForScene(scene);
@@ -5851,6 +5853,7 @@ Hooks.once('setup', () => {
           name: game.i18n.localize('SCENE-PACKER.scene-context.unpack.title'),
           icon: '<i class="fas fa-scroll"></i>',
           condition: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             let instance = ScenePacker.GetInstanceForScene(scene);
@@ -5860,6 +5863,7 @@ Hooks.once('setup', () => {
               game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ENABLE_CONTEXT_MENU);
           },
           callback: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             let instance = ScenePacker.GetInstanceForScene(scene);
@@ -5874,6 +5878,7 @@ Hooks.once('setup', () => {
           ),
           icon: '<i class="fas fa-scroll"></i>',
           condition: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             let instance = ScenePacker.GetInstanceForScene(scene);
@@ -5883,6 +5888,7 @@ Hooks.once('setup', () => {
               game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ENABLE_CONTEXT_MENU);
           },
           callback: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             let instance = ScenePacker.GetInstanceForScene(scene);
@@ -5903,6 +5909,7 @@ Hooks.once('setup', () => {
               game.settings.get(CONSTANTS.MODULE_NAME, CONSTANTS.SETTING_ENABLE_CONTEXT_MENU);
           },
           callback: (li) => {
+            li = li instanceof HTMLElement ? li : li[0];
             let documentId = li.dataset.entryId ?? li.data('documentId') ?? li.data('entityId');
             let scene = game.scenes.get(documentId);
             new globalScenePacker.AssetReport({scene});


### PR DESCRIPTION
- Fixed the fix from v2.8.7 that broke "right clicking" on Scenes in Foundry VTT v12 and below.
  - Yet another casualty to the switching between jQuery and HTML that has happened within core.