### PR TITLE
v2.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.8.10
+
+- Added support for automatically replacing incompatible data when importing packs via the Moulinette importers.
+  - This occurs when you try to import a pack into a system that is different to the system the pack was created in.
+  - All Actors and Items will not be imported (since they are incompatible), a "Placeholder Actor" will be created for scene tokens.
+
 ## v2.8.9
 
 - Further fixes for "right click" context menus.

--- a/languages/en.json
+++ b/languages/en.json
@@ -332,7 +332,8 @@
       "email": "Email:",
       "version": "Version:",
       "more-info": "More info:",
-      "missing-asset": "Missing asset from package data: {asset}"
+      "missing-asset": "Missing asset from package data: {asset}",
+      "incorrect-system": "The system of the pack you are trying to import ({packSystem}) is different from the current system ({currentSystem}) and you may experience issues. Any tokens on scenes will be replaced with a placeholder actor to increase compatibility. Do you wish to proceed?"
     },
     "zip-importer": {
       "name": "Import from Moulinette ZIP",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -308,7 +308,8 @@
       "version": "Version :",
       "more-info": "Plus d'infos :",
       "missing-asset": "Asset manquant dans les données du paquet : {asset}",
-      "unrelated-intro": "Les entités suivantes ne sont pas directement liées à une Scène de ce pack et ont été automatiquement importées pour éviter de briser des liens."
+      "unrelated-intro": "Les entités suivantes ne sont pas directement liées à une Scène de ce pack et ont été automatiquement importées pour éviter de briser des liens.",
+      "incorrect-system": "Le système du pack que vous essayez d’importer ({packSystem}) est différent du système actuel ({currentSystem}) et vous pourriez rencontrer des problèmes. Tous les jetons sur les scènes seront remplacés par un acteur temporaire pour améliorer la compatibilité. Souhaitez-vous continuer?"
     },
     "instance-prompt": {
       "title": "Choisir l'instance",

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "library": "true",
   "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",


### PR DESCRIPTION
- Added support for automatically replacing incompatible data when importing packs via the Moulinette importers.
  - This occurs when you try to import a pack into a system that is different to the system the pack was created in.
  - All Actors and Items will not be imported (since they are incompatible), a "Placeholder Actor" will be created for scene tokens.