### PR TITLE
Add export/import template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.8.12
+
+- Added Export Template feature to Moulinette exporter.
+  - Users can now save their selections and form configuration as a downloadable JSON template file.
+  - Templates can be loaded later to restore selections and settings.
+  - Warning dialog displays when loading templates with documents that no longer exist.
+
+## v2.8.11
+
+- Fixed styling in Journal Entries being impossible to read on dark themes.
+- Fixed asset report not allowing toggling of report entries due to Core CSS conflicts.
+
 ## v2.8.10
 
 - Added support for automatically replacing incompatible data when importing packs via the Moulinette importers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   - Users can now save their selections and form configuration as a downloadable JSON template file.
   - Templates can be loaded later to restore selections and settings.
   - Warning dialog displays when loading templates with documents that no longer exist.
+  - Export templates now remember individually selected playlist sounds, so loading a template no longer exports playlists with zero sounds.
+- Fixed the Moulinette importer sometimes getting stuck on the "Loading data..." spinner the first time a pack was opened, requiring the window to be closed and reopened.
+  - Thank you [BeneosBattlemaps](https://github.com/BeneosBattlemaps) for the contribution.
+- Fixed importing on dnd5e 5.x / Foundry V13 flooding the console with "Failed data preparation" errors by creating imported documents via the system's document class.
+  - Thank you [BeneosBattlemaps](https://github.com/BeneosBattlemaps) for the contribution.
+- Reduced deprecation warnings logged while importing by reading the legacy `core.sourceId` flag directly instead of via the deprecated getter.
 
 ## v2.8.11
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -502,6 +502,7 @@
         "help": "Save your current selections and settings as a template file, or load a previously saved template.",
         "save-success": "Template saved successfully!",
         "load-success": "Template loaded successfully!",
+        "save-error": "Failed to save template: {error}",
         "load-error": "Failed to load template: {error}",
         "invalid-file": "Invalid template file format",
         "missing-warning": "The following items from the template no longer exist in your world:",

--- a/languages/en.json
+++ b/languages/en.json
@@ -494,6 +494,19 @@
       "invalid": {
         "title": "Invalid form data",
         "fields": "<p>The following fields on the <strong>Options</strong> tab require a value:</p><ul>{fields}</ul>"
+      },
+      "template": {
+        "label": "Export Template",
+        "save": "Save Template",
+        "load": "Load Template",
+        "help": "Save your current selections and settings as a template file, or load a previously saved template.",
+        "save-success": "Template saved successfully!",
+        "load-success": "Template loaded successfully!",
+        "load-error": "Failed to load template: {error}",
+        "invalid-file": "Invalid template file format",
+        "missing-warning": "The following items from the template no longer exist in your world:",
+        "missing-continue": "These items will be skipped. Do you want to continue loading the template?",
+        "missing-title": "Missing Items"
       }
     },
     "adventure-converter": {

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -489,6 +489,7 @@
         "help": "Enregistrez vos sélections et paramètres actuels sous forme de fichier modèle, ou chargez un modèle précédemment enregistré.",
         "save-success": "Modèle enregistré avec succès !",
         "load-success": "Modèle chargé avec succès !",
+        "save-error": "Échec de l'enregistrement du modèle : {error}",
         "load-error": "Échec du chargement du modèle : {error}",
         "invalid-file": "Format de fichier de modèle invalide",
         "missing-warning": "Les éléments suivants du modèle n'existent plus dans votre monde :",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -481,6 +481,19 @@
       "invalid": {
         "title": "forme de donné non valide",
         "fields": "<p>Les champs suivants de l'onglet <strong>Options</strong> nécessitent une valeur :</p><ul>{fields}</ul>"
+      },
+      "template": {
+        "label": "Modèle d'exportation",
+        "save": "Enregistrer le modèle",
+        "load": "Charger le modèle",
+        "help": "Enregistrez vos sélections et paramètres actuels sous forme de fichier modèle, ou chargez un modèle précédemment enregistré.",
+        "save-success": "Modèle enregistré avec succès !",
+        "load-success": "Modèle chargé avec succès !",
+        "load-error": "Échec du chargement du modèle : {error}",
+        "invalid-file": "Format de fichier de modèle invalide",
+        "missing-warning": "Les éléments suivants du modèle n'existent plus dans votre monde :",
+        "missing-continue": "Ces éléments seront ignorés. Voulez-vous continuer à charger le modèle ?",
+        "missing-title": "Éléments manquants"
       }
     },
     "adventure-converter": {

--- a/module.json
+++ b/module.json
@@ -6,10 +6,10 @@
   "version": "2.8.12",
   "library": "true",
   "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "13",
+  "compatibleCoreVersion": "14",
   "compatibility": {
     "minimum": "0.8.6",
-    "verified": "13"
+    "verified": "14"
   },
   "author": "Blair McMillan",
   "authors": [
@@ -67,19 +67,11 @@
     {
       "name": "Scene Packer",
       "sorting": "a",
-      "packs": [
-        "journals",
-        "macros"
-      ]
+      "packs": ["journals", "macros"]
     }
   ],
-  "esmodules": [
-    "/scripts/scene-packer.js",
-    "/scripts/wrapped.js"
-  ],
-  "styles": [
-    "styles/scene-packer.css"
-  ],
+  "esmodules": ["/scripts/scene-packer.js", "/scripts/wrapped.js"],
+  "styles": ["styles/scene-packer.css"],
   "languages": [
     {
       "lang": "en",
@@ -100,14 +92,8 @@
   "flags": {
     "allowBugReporter": true,
     "hotReload": {
-      "extensions": [
-        "css",
-        "hbs"
-      ],
-      "paths": [
-        "styles",
-        "templates"
-      ]
+      "extensions": ["css", "hbs"],
+      "paths": ["styles", "templates"]
     },
     "suppressedWarnings": [
       "name",

--- a/module.json
+++ b/module.json
@@ -3,9 +3,8 @@
   "name": "scene-packer",
   "title": "Library: Scene Packer",
   "description": "A module to assist with Scene and Adventure packing and unpacking.",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "library": "true",
-  "manifestPlusVersion": "1.2.0",
   "minimumCoreVersion": "0.8.6",
   "compatibleCoreVersion": "13",
   "compatibility": {
@@ -109,6 +108,12 @@
         "styles",
         "templates"
       ]
-    }
+    },
+    "suppressedWarnings": [
+      "name",
+      "minimumCoreVersion",
+      "compatibleCoreVersion",
+      "author"
+    ]
   }
 }

--- a/scripts/assets/journal.js
+++ b/scripts/assets/journal.js
@@ -155,7 +155,7 @@ export async function ExtractQuickEncounterAssets(journal) {
       const actor = game.actors.find((a) => {
         return (
           (a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === extractedActor.actorID ||
-            (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === extractedActor.actorID ||
+            (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === extractedActor.actorID ||
             a.id === extractedActor.actorID) &&
           !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated')
         );

--- a/scripts/export-import/exporter-template.js
+++ b/scripts/export-import/exporter-template.js
@@ -99,15 +99,7 @@ export class ExporterTemplate {
     }
 
     if (!json.templateVersion) {
-      if (typeof json === 'string') {
-        try {
-          json = JSON.parse(json);
-        } catch (err) {
-          throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
-        }
-      } else {
-        throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
-      }
+      throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
     }
 
     if (json.templateVersion !== ExporterTemplate.TEMPLATE_VERSION) {

--- a/scripts/export-import/exporter-template.js
+++ b/scripts/export-import/exporter-template.js
@@ -170,7 +170,12 @@ export class ExporterTemplate {
       const exportName = this.name ?? 'scene-packer-template';
       const now = new Date();
       const dateStr = now.toISOString().slice(0, 16).replace('T', '-').replace(/:/g, '');
-      filename = `export-${exportName}-${dateStr}.json`;
+      filename = `export-${exportName}-${dateStr}`;
+    }
+
+    // Ensure a .json extension regardless of whether a custom filename was passed.
+    if (!filename.toLowerCase().endsWith('.json')) {
+      filename += '.json';
     }
 
     const content = this.toJSON();
@@ -182,7 +187,7 @@ export class ExporterTemplate {
       // Create an element to trigger the download
       const a = document.createElement('a');
       a.href = window.URL.createObjectURL(blob);
-      a.download = `${filename}.json`;
+      a.download = filename;
 
       // Dispatch a click event to the element
       a.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, view: window}));

--- a/scripts/export-import/exporter-template.js
+++ b/scripts/export-import/exporter-template.js
@@ -1,0 +1,200 @@
+export class ExporterTemplate {
+  static TEMPLATE_VERSION = '1.0.0';
+
+  constructor({
+    templateVersion = ExporterTemplate.TEMPLATE_VERSION,
+    name = '',
+    author = '',
+    version = '',
+    description = '',
+    cover_image = '',
+    external_link = '',
+    email = '',
+    discordId = '',
+    system = '',
+    category = '',
+    play_hours = 0,
+    welcome_journal = '',
+    welcome_journal_name = '',
+    allow_complete_import = true,
+    players = { min: 0, max: 0, recommended: 0 },
+    player_levels = [],
+    token_styles = [],
+    pregen = false,
+    grid = [],
+    themes = [],
+    tags = [],
+    selections = {}
+  } = {}) {
+    this.templateVersion = templateVersion;
+    this.name = name;
+    this.author = author;
+    this.version = version;
+    this.description = description;
+    this.cover_image = cover_image;
+    this.external_link = external_link;
+    this.email = email;
+    this.discordId = discordId;
+    this.system = system;
+    this.category = category;
+    this.play_hours = play_hours;
+    this.welcome_journal = welcome_journal;
+    this.welcome_journal_name = welcome_journal_name;
+    this.allow_complete_import = allow_complete_import;
+    this.players = players;
+    this.player_levels = player_levels;
+    this.token_styles = token_styles;
+    this.pregen = pregen;
+    this.grid = grid;
+    this.themes = themes;
+    this.tags = tags;
+    this.selections = selections;
+  }
+
+  /**
+   * Serialize template to JSON string
+   * @returns {string} JSON representation
+   */
+  toJSON() {
+    return JSON.stringify({
+      templateVersion: this.templateVersion,
+      name: this.name,
+      author: this.author,
+      version: this.version,
+      description: this.description,
+      cover_image: this.cover_image,
+      external_link: this.external_link,
+      email: this.email,
+      discordId: this.discordId,
+      system: this.system,
+      category: this.category,
+      play_hours: this.play_hours,
+      welcome_journal: this.welcome_journal,
+      welcome_journal_name: this.welcome_journal_name,
+      allow_complete_import: this.allow_complete_import,
+      players: this.players,
+      player_levels: this.player_levels,
+      token_styles: this.token_styles,
+      pregen: this.pregen,
+      grid: this.grid,
+      themes: this.themes,
+      tags: this.tags,
+      selections: this.selections
+    }, null, 2);
+  }
+
+  /**
+   * Parse JSON to ExporterTemplate instance
+   * @param {string|object} json - JSON string or object
+   * @returns {ExporterTemplate}
+   * @throws {Error} If JSON is invalid
+   */
+  static fromJSON(json) {
+    if (typeof json === 'string') {
+      try {
+        json = JSON.parse(json);
+      } catch (err) {
+        throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
+      }
+    }
+
+    if (!json.templateVersion) {
+      if (typeof json === 'string') {
+        try {
+          json = JSON.parse(json);
+        } catch (err) {
+          throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
+        }
+      } else {
+        throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
+      }
+    }
+
+    if (json.templateVersion !== ExporterTemplate.TEMPLATE_VERSION) {
+      throw new Error(`Unsupported template version: ${json.templateVersion}`);
+    }
+
+    if (!json.selections || typeof json.selections !== 'object') {
+      throw new Error(game.i18n.localize('SCENE-PACKER.exporter.template.invalid-file'));
+    }
+
+    return new ExporterTemplate(json);
+  }
+
+  /**
+   * Get list of items from template that no longer exist in the world
+   * @returns {Array<{type: string, id: string, name: string}>}
+   */
+  getMissingItems() {
+    const missing = [];
+
+    if (this.welcome_journal) {
+      const journal = game.journal.get(this.welcome_journal);
+      if (!journal) {
+        missing.push({
+          type: 'Welcome Journal',
+          id: this.welcome_journal,
+          name: this.welcome_journal_name || 'Unknown'
+        });
+      }
+    }
+
+    for (const [type, docs] of Object.entries(this.selections)) {
+      if (type === 'Folder') {
+        for (const folder of docs) {
+          if (!game.folders.get(folder.id)) {
+            missing.push({
+              type: `${folder.type} Folder`,
+              id: folder.id,
+              name: folder.name
+            });
+          }
+        }
+      } else {
+        const collection = game.collections.get(type);
+        if (!collection) continue;
+
+        for (const doc of docs) {
+          if (!collection.get(doc.id)) {
+            missing.push({
+              type,
+              id: doc.id,
+              name: doc.name
+            });
+          }
+        }
+      }
+    }
+
+    return missing;
+  }
+
+  /**
+   * Trigger browser download of template as JSON file
+   * @param {string} [filename] - Optional custom filename
+   */
+  async download(filename) {
+    if (!filename) {
+      const exportName = this.name ?? 'scene-packer-template';
+      const now = new Date();
+      const dateStr = now.toISOString().slice(0, 16).replace('T', '-').replace(/:/g, '');
+      filename = `export-${exportName}-${dateStr}.json`;
+    }
+
+    const content = this.toJSON();
+    if (typeof foundry?.utils?.saveDataToFile === 'function') {
+      foundry.utils.saveDataToFile(content, "text/json", filename);
+    } else {
+      const blob = new Blob([content], {type: 'text/json'});
+
+      // Create an element to trigger the download
+      const a = document.createElement('a');
+      a.href = window.URL.createObjectURL(blob);
+      a.download = `${filename}.json`;
+
+      // Dispatch a click event to the element
+      a.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, view: window}));
+      setTimeout(() => window.URL.revokeObjectURL(a.href), 100);
+    }
+  }
+}

--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -559,6 +559,24 @@ export default class Exporter extends FormApplication {
       });
     });
 
+    // Capture individually-selected playlist sounds. PlaylistSound is an
+    // embedded document (no top-level collection), so resolve its name by
+    // looking it up inside the playlists. This lets a saved template carry the
+    // exact sounds a package uses, so the playlist is trimmed on export.
+    selections.PlaylistSound = [];
+    this.element.find('input[data-type="PlaylistSound"]:checked').each((i, el) => {
+      const id = el.value;
+      let name = id;
+      for (const playlist of game.playlists) {
+        const sound = playlist.sounds.get(id);
+        if (sound) {
+          name = sound.name;
+          break;
+        }
+      }
+      selections.PlaylistSound.push({ id, name });
+    });
+
     return {
       name: formData.packageName,
       author: formData.author,
@@ -769,6 +787,16 @@ export default class Exporter extends FormApplication {
           });
         }
       });
+
+      // Restore individually-selected playlist sounds. PlaylistSound is an
+      // embedded document with no top-level CONFIG collection, so it is handled
+      // separately from the documentTypes loop above: just tick the matching
+      // sound checkbox if it exists in the rendered playlist tree.
+      if (Array.isArray(template.selections.PlaylistSound)) {
+        template.selections.PlaylistSound.forEach(item => {
+          this.element.find(`input[data-type="PlaylistSound"][value="${item.id}"]`).prop('checked', true);
+        });
+      }
     }
 
     let scenePackerExporter = $('#scene-packer-exporter');

--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -1,5 +1,6 @@
 import { CONSTANTS } from '../constants.js';
 import ExporterProgress from './exporter-progress.js';
+import { ExporterTemplate } from './exporter-template.js';
 
 export default class Exporter extends FormApplication {
   constructor(object, options) {
@@ -427,6 +428,355 @@ export default class Exporter extends FormApplication {
     }, 500, exporter);
   }
 
+  /**
+   * Collect all form data from the exporter form
+   * @returns {Object} Object containing all form metadata and document selections
+   * @private
+   */
+  _collectFormData() {
+    const form = this.element.find('form')[0];
+    const formData = new FormDataExtended(form).object;
+
+    let welcomeJournalName = '';
+    if (formData.welcomeJournal) {
+      const collection = CONFIG.JournalEntry?.collection?.instance;
+      if (collection) {
+        const journal = collection.get(formData.welcomeJournal);
+        if (journal) {
+          welcomeJournalName = journal.name;
+        }
+      }
+    }
+
+    const players = {};
+    const recommendedPlayers = parseInt(formData.playersRecommended, 10);
+    const minPlayers = parseInt(formData.playersMin, 10);
+    const maxPlayers = parseInt(formData.playersMax, 10);
+    if (recommendedPlayers) {
+      players.recommended = recommendedPlayers;
+    }
+    if (minPlayers) {
+      players.min = minPlayers;
+    }
+    if (maxPlayers) {
+      players.max = maxPlayers;
+    }
+
+    // Collect player levels - handle both single values and arrays
+    const playerLevels = [];
+    if (typeof formData.playerLevelRecommended === 'number' || typeof formData.playerLevelMin === 'number' || typeof formData.playerLevelMax === 'number') {
+      const recommended = parseInt(formData.playerLevelRecommended, 10);
+      const min = parseInt(formData.playerLevelMin, 10);
+      const max = parseInt(formData.playerLevelMax, 10);
+      const playerLever = {};
+      if (Number.isFinite(recommended)) {
+        playerLever.recommended = recommended;
+      }
+      if (Number.isFinite(min)) {
+        playerLever.min = min;
+      }
+      if (Number.isFinite(max)) {
+        playerLever.max = max;
+      }
+
+      if (Object.keys(playerLever).length > 0) {
+        playerLevels.push(playerLever);
+      }
+    }
+
+    if (formData.playerLevelMin?.length || formData.playerLevelMax?.length || formData.playerLevelRecommended?.length) {
+      const minArr = Array.isArray(formData.playerLevelMin) ? formData.playerLevelMin : [];
+      const maxArr = Array.isArray(formData.playerLevelMax) ? formData.playerLevelMax : [];
+      const recArr = Array.isArray(formData.playerLevelRecommended) ?
+        formData.playerLevelRecommended :
+        [];
+
+      const longestLength = Math.max(minArr.length, maxArr.length, recArr.length);
+
+      for (let i = 0; i < longestLength; i++) {
+        const recommended = parseInt(recArr[i], 10);
+        const min = parseInt(minArr[i], 10);
+        const max = parseInt(maxArr[i], 10);
+
+        const playerLevel = {};
+        if (Number.isFinite(recommended)) {
+          playerLevel.recommended = recommended;
+        }
+        if (Number.isFinite(min)) {
+          playerLevel.min = min;
+        }
+        if (Number.isFinite(max)) {
+          playerLevel.max = max;
+        }
+
+        if (Object.keys(playerLevel).length > 0) {
+          playerLevels.push(playerLevel);
+        }
+      }
+    }
+
+    const tokenStyles = [];
+    this.element.find('input[name="tokenStyles"]:checked').each((i, el) => {
+      tokenStyles.push(el.value);
+    });
+
+    const grid = [];
+    this.element.find('input[name="grid"]:checked').each((i, el) => {
+      grid.push(el.value);
+    });
+
+    const pregen = formData.pregen === 'yes';
+
+    const themes = Array.from(new Set(
+      (formData.themes || '').split(',')
+        .map(e => e.toLowerCase().trim())
+        .filter(e => e)
+    ));
+
+    const tags = Array.from(new Set(
+      (formData.tags || '').split(',')
+        .map(e => e.toLowerCase().trim())
+        .filter(e => e)
+    ));
+
+    const documentTypes = [...CONSTANTS.PACK_IMPORT_ORDER, 'Folder'];
+    const selections = {};
+
+    documentTypes.forEach(type => {
+      selections[type] = [];
+      this.element.find(`input[data-type="${type}"]:checked`).each((i, el) => {
+        const id = el.value;
+        const collection = CONFIG[type]?.collection?.instance;
+        if (collection) {
+          const doc = collection.get(id);
+          if (doc) {
+            selections[type].push({
+              id: doc.id,
+              name: doc.name,
+            });
+          }
+        }
+      });
+    });
+
+    return {
+      name: formData.packageName,
+      author: formData.author,
+      version: formData.version,
+      description: this.editors?.packageDescription?.mce?.getContent() || '',
+      cover_image: formData.packageCover,
+      external_link: formData.externalLink,
+      email: formData.email,
+      discordId: formData.discordId,
+      system: formData.system || '',
+      category: formData.adventureCategory || '',
+      play_hours: parseInt(formData.duration, 10) || 0,
+      welcome_journal: formData.welcomeJournal,
+      welcome_journal_name: welcomeJournalName,
+      allow_complete_import: formData.allowCompleteImport === 'yes',
+      players: players,
+      player_levels: playerLevels,
+      token_styles: tokenStyles,
+      grid: grid,
+      pregen: pregen,
+      themes: themes,
+      tags: tags,
+      selections: selections,
+    };
+  }
+
+  /**
+   * Handler for Save Template button
+   * @param {Event} event
+   */
+  async _saveTemplate(event) {
+    event.preventDefault();
+
+    try {
+      const template = new ExporterTemplate(this._collectFormData());
+      template.download();
+
+      ui.notifications.info(game.i18n.localize('SCENE-PACKER.exporter.template.save-success'));
+    } catch (err) {
+      console.error('Error saving template:', err);
+      ui.notifications.error(
+        game.i18n.format('SCENE-PACKER.exporter.template.load-error', { error: err.message })
+      );
+    }
+  }
+
+  /**
+   * Handler for Load Template button
+   * @param {Event} event
+   */
+  async _loadTemplate(event) {
+    event.preventDefault();
+
+    // Create file input element
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json,application/json';
+
+    input.onchange = async (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      try {
+        const text = await file.text();
+        const template = ExporterTemplate.fromJSON(text);
+        const missing = template.getMissingItems();
+
+        if (missing.length > 0) {
+          const proceed = await this._showMissingItemsDialog(missing);
+          if (!proceed) {
+            return;
+          }
+        }
+
+        await this._applyTemplate(template);
+
+        ui.notifications.info(game.i18n.localize('SCENE-PACKER.exporter.template.load-success'));
+      } catch (err) {
+        console.error('Error loading template:', err);
+        ui.notifications.error(
+          game.i18n.format('SCENE-PACKER.exporter.template.load-error', { error: err.message })
+        );
+      }
+    };
+
+    input.click();
+  }
+
+  /**
+   * Show dialog warning about missing items
+   * @param {Array} missingItems - Array of missing items
+   * @returns {Promise<boolean>} True if user wants to proceed
+   */
+  async _showMissingItemsDialog(missingItems) {
+    const content = await renderTemplate(
+      'modules/scene-packer/templates/export-import/template-missing-documents.hbs',
+      { missingItems }
+    );
+
+    return Dialog.confirm({
+      title: game.i18n.localize('SCENE-PACKER.exporter.template.missing-title'),
+      content: content,
+      yes: () => true,
+      no: () => false,
+      defaultYes: false
+    });
+  }
+
+  /**
+   * Apply a template to the form
+   * @param {ExporterTemplate} template
+   */
+  async _applyTemplate(template) {
+    this.element.find('#SP-export-packageName').val(template.name || '');
+    this.element.find('#SP-export-author').val(template.author || '');
+    this.element.find('#SP-export-version').val(template.version || '');
+    this.element.find('#SP-export-packageCover').val(template.cover_image || '');
+    this.element.find('#SP-export-email').val(template.email || '');
+    this.element.find('#SP-export-discordId').val(template.discordId || '');
+    this.element.find('#SP-export-externalLink').val(template.external_link || '');
+    this.element.find('#SP-export-welcomeJournal').val(template.welcome_journal || '');
+    this.element.find('#SP-export-system').val(template.system || '');
+    this.element.find('#SP-export-adventureCategory').val(template.category || '');
+    this.element.find('#SP-export-duration').val(template.play_hours || '');
+
+    if (this.editors?.packageDescription?.mce) {
+      this.editors.packageDescription.mce.setContent(template.description || '');
+    }
+
+    if (template.players) {
+      this.element.find('#SP-export-playersRecommended').val(template.players.recommended || '');
+      this.element.find('#SP-export-playersMin').val(template.players.min || '');
+      this.element.find('#SP-export-playersMax').val(template.players.max || '');
+    }
+
+    const playerLevelsContainer = this.element.find('#SP-export-player-levels-add').parent();
+    playerLevelsContainer.find('.form-group').not(':first').remove();
+
+    if (template.player_levels && template.player_levels.length > 0) {
+      const firstRow = playerLevelsContainer.find('.form-group').first();
+      const firstLevel = template.player_levels[0];
+      firstRow.find('input[name="playerLevelRecommended"]').val(firstLevel.recommended || '');
+      firstRow.find('input[name="playerLevelMin"]').val(firstLevel.min || '');
+      firstRow.find('input[name="playerLevelMax"]').val(firstLevel.max || '');
+
+      for (let i = 1; i < template.player_levels.length; i++) {
+        const level = template.player_levels[i];
+        const playerLevelContent = `<div class="form-group">
+                <input type="number" name="playerLevelRecommended" min="0" value="${level.recommended || ''}" placeholder="${game.i18n.localize('SCENE-PACKER.exporter.options.adventure-player-level-recommended-placeholder')}" autocomplete="off">
+                <input type="number" name="playerLevelMin" min="0" value="${level.min || ''}" placeholder="${game.i18n.localize('SCENE-PACKER.exporter.options.adventure-player-level-min-placeholder')}" autocomplete="off">
+                <input type="number" name="playerLevelMax" min="0" value="${level.max || ''}" placeholder="${game.i18n.localize('SCENE-PACKER.exporter.options.adventure-player-level-max-placeholder')}" autocomplete="off">
+                <span class="spacer"></span>
+              </div>`;
+        $(playerLevelContent).insertBefore(this.element.find('#SP-export-player-levels-add'));
+      }
+    }
+
+    this.element.find('input[name="grid"]').prop('checked', false);
+    if (template.grid && Array.isArray(template.grid)) {
+      template.grid.forEach(gridType => {
+        this.element.find(`input[name="grid"][value="${gridType}"]`).prop('checked', true);
+      });
+    }
+
+    this.element.find('input[name="tokenStyles"]').prop('checked', false);
+    if (template.token_styles && Array.isArray(template.token_styles)) {
+      template.token_styles.forEach(style => {
+        this.element.find(`input[name="tokenStyles"][value="${style}"]`).prop('checked', true);
+      });
+    }
+
+    if (template.pregen) {
+      this.element.find('#SP-export-pregen-yes').prop('checked', true);
+      this.element.find('#SP-export-pregen-no').prop('checked', false);
+    } else {
+      this.element.find('#SP-export-pregen-yes').prop('checked', false);
+      this.element.find('#SP-export-pregen-no').prop('checked', true);
+    }
+
+    if (template.allow_complete_import) {
+      this.element.find('#SP-export-allow-import-yes').prop('checked', true);
+      this.element.find('#SP-export-allow-import-no').prop('checked', false);
+    } else {
+      this.element.find('#SP-export-allow-import-yes').prop('checked', false);
+      this.element.find('#SP-export-allow-import-no').prop('checked', true);
+    }
+
+    if (template.themes && Array.isArray(template.themes)) {
+      this.element.find('#SP-export-theme').val(template.themes.join(', '));
+    }
+
+    if (template.tags && Array.isArray(template.tags)) {
+      this.element.find('#SP-export-tags').val(template.tags.join(', '));
+    }
+
+    this.element.find('div.tab:not([data-tab=options]) input[type="checkbox"]').prop('checked', false);
+
+    if (template.selections) {
+      const documentTypes = ['Scene', 'Actor', 'Item', 'JournalEntry', 'RollTable', 'Cards', 'Playlist', 'Macro', 'Folder'];
+
+      documentTypes.forEach(type => {
+        if (template.selections[type] && Array.isArray(template.selections[type])) {
+          template.selections[type].forEach(item => {
+            const collection = CONFIG[type]?.collection?.instance;
+            if (collection && collection.get(item.id)) {
+              this.element.find(`input[data-type="${type}"][value="${item.id}"]`).prop('checked', true);
+            }
+          });
+        }
+      });
+    }
+
+    let scenePackerExporter = $('#scene-packer-exporter');
+    this.selected = scenePackerExporter.find('div.tab:not([data-tab=options]) input[type="checkbox"]:checked');
+
+    this._updateCounts();
+  }
+
   /** @inheritdoc */
   activateListeners(html) {
     super.activateListeners(html);
@@ -487,6 +837,8 @@ export default class Exporter extends FormApplication {
     }
 
     html.find('button[name="close"]').click(this.close.bind(this));
+    html.find('.save-template').click(this._saveTemplate.bind(this));
+    html.find('.load-template').click(this._loadTemplate.bind(this));
   }
 
   /** @inheritdoc */
@@ -792,36 +1144,21 @@ export class ExporterData {
   DownloadJSON() {
     const content = JSON.stringify(this, null, 2);
     const filename = this.name.slugify({ strict: true }) || 'export';
-    const blob = new Blob([content], {type: 'text/plain;charset=utf-8'});
-    if (typeof window.navigator.msSaveBlob !== 'undefined') {
-      // IE doesn't allow using a blob object directly as link href.
-      // Workaround for "HTML7007: One or more blob URLs were
-      // revoked by closing the blob for which they were created.
-      // These URLs will no longer resolve as the data backing
-      // the URL has been freed."
-      window.navigator.msSaveBlob(blob, `${filename}.json`);
-      return;
-    }
 
-    // Create a link pointing to the ObjectURL containing the blob
-    const blobURL = URL.createObjectURL(blob);
-    const tempLink = document.createElement('a');
-    tempLink.style.display = 'none';
-    tempLink.setAttribute('href', blobURL);
-    tempLink.setAttribute('download', `${filename}.json`);
-    // Safari thinks _blank anchor are pop ups. We only want to set _blank
-    // target if the browser does not support the HTML5 download attribute.
-    // This allows you to download files in desktop safari if pop up blocking
-    // is enabled.
-    if (typeof tempLink.download === 'undefined') {
-      tempLink.setAttribute('target', '_blank');
-    }
-    tempLink.click();
+    if (typeof foundry?.utils?.saveDataToFile === 'function') {
+      foundry.utils.saveDataToFile(content, 'text/json', `${filename}.json`);
+    } else {
+      const blob = new Blob([content], {type: 'text/json'});
 
-    setTimeout(() => {
-      // For Firefox it is necessary to delay revoking the ObjectURL
-      URL.revokeObjectURL(blobURL);
-    }, 200);
+      // Create an element to trigger the download
+      const a = document.createElement('a');
+      a.href = window.URL.createObjectURL(blob);
+      a.download = `${filename}.json`;
+
+      // Dispatch a click event to the element
+      a.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, view: window}));
+      setTimeout(() => window.URL.revokeObjectURL(a.href), 100);
+    }
   }
 
   /**

--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -618,7 +618,7 @@ export default class Exporter extends FormApplication {
     } catch (err) {
       console.error('Error saving template:', err);
       ui.notifications.error(
-        game.i18n.format('SCENE-PACKER.exporter.template.load-error', { error: err.message })
+        game.i18n.format('SCENE-PACKER.exporter.template.save-error', { error: err.message })
       );
     }
   }

--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -48,6 +48,7 @@ export default class MoulinetteImporter extends FormApplication {
     this.processingMessage = '';
     this.errorMessage = '';
     this.loading = true;
+    this.pendingRender = false;
 
     if (!this.packInfo || !this.packInfo['mtte.json']) {
       ScenePacker.logType(
@@ -57,7 +58,7 @@ export default class MoulinetteImporter extends FormApplication {
         game.i18n.localize('SCENE-PACKER.importer.invalid-pack-data'),
       );
       this.errorMessage = game.i18n.localize('SCENE-PACKER.importer.invalid-pack-data');
-      this.render();
+      this.render(true);
 
       return;
     }
@@ -72,8 +73,48 @@ export default class MoulinetteImporter extends FormApplication {
 
         return;
       }
-      this.render();
+      this.requestRender();
+    }).catch(err => {
+      this.loading = true;
+      this.errorMessage = game.i18n.localize('SCENE-PACKER.importer.invalid-pack-data');
+      ScenePacker.logType(
+        game.i18n.localize('SCENE-PACKER.importer.name'),
+        'error',
+        true,
+        err?.message ?? String(err),
+      );
+      this.requestRender();
     });
+  }
+
+  /**
+   * Render the importer once the package metadata has loaded.
+   *
+   * The importer is opened externally by Moulinette via `render(true)`, which
+   * begins an asynchronous render. The metadata fetch frequently resolves while
+   * that initial render is still in progress. `Application._render` ignores any
+   * render requested while the Application is in the RENDERING state (even a
+   * forced one), so a render triggered here would be silently dropped and the
+   * window would stay stuck on the loading spinner with the import buttons
+   * disabled until it was closed and reopened. To avoid that race the render is
+   * deferred until the in-progress render finishes (flushed in `_render`).
+   */
+  requestRender() {
+    if (this._state === this.constructor.RENDER_STATES.RENDERING) {
+      this.pendingRender = true;
+
+      return;
+    }
+    this.render(true);
+  }
+
+  /** @inheritdoc */
+  async _render(force, options) {
+    await super._render(force, options);
+    if (this.pendingRender) {
+      this.pendingRender = false;
+      await super._render(true, options);
+    }
   }
 
   /**

--- a/scripts/export-import/related/journals.js
+++ b/scripts/export-import/related/journals.js
@@ -107,7 +107,7 @@ export function ExtractRelatedQuickEncounterData(journal) {
     const journal = game.journal.find((a) => {
       return (
         (a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === quickEncounter.journalEntryId ||
-          (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === quickEncounter.journalEntryId ||
+          (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === quickEncounter.journalEntryId ||
           a.id === quickEncounter.journalEntryId) &&
         !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated')
       );
@@ -124,7 +124,7 @@ export function ExtractRelatedQuickEncounterData(journal) {
       const actor = game.actors.find((a) => {
         return (
           (a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === extractedActor.actorID ||
-            (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === extractedActor.actorID ||
+            (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === extractedActor.actorID ||
             a.id === extractedActor.actorID) &&
           !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated')
         );

--- a/scripts/export-import/zip-importer.js
+++ b/scripts/export-import/zip-importer.js
@@ -319,11 +319,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await Scene.createDocuments(await Promise.all(documents.map(async d => Scene.fromImport({...d, active: false}))), { keepId: true });
+        created = await getDocumentClass("Scene").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Scene").fromImport({...d, active: false}))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await Scene.createDocuments(documents.map(d => Scene.fromSource({...d, active: false}).toObject()), { keepId: true });
+        created = await getDocumentClass("Scene").createDocuments(documents.map(d => getDocumentClass("Scene").fromSource({...d, active: false}).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the scenes and update them to local world references
@@ -373,11 +373,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await Actor.createDocuments(await Promise.all(documents.map(async d => Actor.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("Actor").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Actor").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await Actor.createDocuments(documents.map(d => Actor.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("Actor").createDocuments(documents.map(d => getDocumentClass("Actor").fromSource(d).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the actors and update them to local world references
@@ -443,11 +443,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await JournalEntry.createDocuments(await Promise.all(documents.map(async d => JournalEntry.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("JournalEntry").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("JournalEntry").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await JournalEntry.createDocuments(documents.map(d => JournalEntry.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("JournalEntry").createDocuments(documents.map(d => getDocumentClass("JournalEntry").fromSource(d).toObject()), { keepId: true });
       }
       if (this.scenePackerInfo?.welcome_journal) {
         if (created.find(j => j.id === this.scenePackerInfo.welcome_journal)) {
@@ -491,11 +491,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await Item.createDocuments(await Promise.all(documents.map(async d => Item.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("Item").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Item").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await Item.createDocuments(documents.map(d => Item.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("Item").createDocuments(documents.map(d => getDocumentClass("Item").fromSource(d).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the items and update them to local world references
@@ -533,11 +533,11 @@ export default class ZipImporter extends FormApplication {
       }
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        await Macro.createDocuments(await Promise.all(documents.map(async d => Macro.fromImport(d))), { keepId: true });
+        await getDocumentClass("Macro").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Macro").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        await Macro.createDocuments(documents.map(d => Macro.fromSource(d).toObject()), { keepId: true });
+        await getDocumentClass("Macro").createDocuments(documents.map(d => getDocumentClass("Macro").fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -571,7 +571,7 @@ export default class ZipImporter extends FormApplication {
         }
         const playlistData = existingPlaylist.toJSON();
         const sounds = playlistData.sounds || [];
-        const newPlaylistData = Playlist.fromSource(d).toObject();
+        const newPlaylistData = getDocumentClass("Playlist").fromSource(d).toObject();
         const newSounds = [];
         let hasUpdates = false;
         for (const sound of (newPlaylistData.sounds || [])) {
@@ -596,11 +596,11 @@ export default class ZipImporter extends FormApplication {
       if (documents.length) {
         if (CONSTANTS.IsV12orNewer()) {
           // Run via the .fromImport method as that migrates data from old game versions.
-          await Playlist.createDocuments(await Promise.all(documents.map(async d => Playlist.fromImport(d))), { keepId: true });
+          await getDocumentClass("Playlist").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Playlist").fromImport(d))), { keepId: true });
         } else {
           // Run via the .fromSource method as that operates in a non-strict validation format, allowing
           // for older formats to still be parsed in most cases.
-          await Playlist.createDocuments(documents.map(d => Playlist.fromSource(d).toObject()), { keepId: true });
+          await getDocumentClass("Playlist").createDocuments(documents.map(d => getDocumentClass("Playlist").fromSource(d).toObject()), { keepId: true });
         }
       }
     }
@@ -628,11 +628,11 @@ export default class ZipImporter extends FormApplication {
       }
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions.
-        await Cards.createDocuments(await Promise.all(documents.map(async d => Cards.fromImport(d))), { keepId: true });
+        await getDocumentClass("Cards").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Cards").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        await Cards.createDocuments(documents.map(d => Cards.fromSource(d).toObject()), { keepId: true });
+        await getDocumentClass("Cards").createDocuments(documents.map(d => getDocumentClass("Cards").fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -660,11 +660,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions.
-        created = await RollTable.createDocuments(await Promise.all(documents.map(async d => RollTable.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("RollTable").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("RollTable").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await RollTable.createDocuments(documents.map(d => RollTable.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("RollTable").createDocuments(documents.map(d => getDocumentClass("RollTable").fromSource(d).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the roll tables and update them to local world references

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -229,21 +229,21 @@ export default class ScenePacker {
           // The yes callback during an upgrade of a module removes all existing entries that came from this module before
           // importing everything in again.
           // Folders are untouched.
-          const scenes = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const scenes = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const actors = game.actors.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const actors = game.actors.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const items = game.items.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const items = game.items.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const journals = game.journal.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const journals = game.journal.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const rollTables = game.tables.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const rollTables = game.tables.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const playlists = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const playlists = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const macros = game.macros.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const macros = game.macros.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const cards = game.cards.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const cards = game.cards.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
 
           let listToDelete = '';
@@ -276,49 +276,49 @@ export default class ScenePacker {
           }
 
           const doReplacement = async function () {
-            const sceneIDs = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const sceneIDs = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (sceneIDs.length) {
               await Scene.deleteDocuments(sceneIDs);
             }
-            const actorIDs = game.actors.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const actorIDs = game.actors.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (actorIDs.length) {
               await Actor.deleteDocuments(actorIDs);
             }
-            const itemIDs = game.items.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const itemIDs = game.items.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (itemIDs.length) {
               await Item.deleteDocuments(itemIDs);
             }
-            const journalIDs = game.journal.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const journalIDs = game.journal.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (journalIDs.length) {
               await JournalEntry.deleteDocuments(journalIDs);
             }
-            const rollTableIDs = game.tables.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const rollTableIDs = game.tables.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (rollTableIDs.length) {
               await RollTable.deleteDocuments(rollTableIDs);
             }
-            const playlistIDs = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const playlistIDs = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (playlistIDs.length) {
               await Playlist.deleteDocuments(playlistIDs);
             }
-            const macroIDs = game.macros.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const macroIDs = game.macros.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (macroIDs.length) {
               await Macro.deleteDocuments(macroIDs);
             }
-            const cardIDs = game.cards.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const cardIDs = game.cards.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (cardIDs.length) {
@@ -466,10 +466,10 @@ export default class ScenePacker {
               return true;
             }
             let sourceId = e._stats?.compendiumSource ?? e.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
-            let coreSourceId = e._stats?.compendiumSource ?? e.getFlag('core', 'sourceId');
+            let coreSourceId = e._stats?.compendiumSource ?? e.flags?.core?.sourceId;
             const hasExistingEntryWithID = collection.get(e.id);
             if (hasExistingEntryWithID || sourceId || coreSourceId) {
-              const existingEntries = collection.filter(f => f.id === e.id || (sourceId && f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sourceId) || (coreSourceId && (f._stats?.compendiumSource ?? f.getFlag('core', 'sourceId')) === coreSourceId));
+              const existingEntries = collection.filter(f => f.id === e.id || (sourceId && f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sourceId) || (coreSourceId && (f._stats?.compendiumSource ?? f.flags?.core?.sourceId) === coreSourceId));
               if (existingEntries.length && forceImport && renameOriginals) {
                 // Update the existing entry names
                 const newFlags = {};
@@ -619,7 +619,7 @@ export default class ScenePacker {
                   // so the current version flag won't have been set yet.
                   if (foundry.utils.isNewerVersion(moduleVersion, importedVersion)) {
                     let welcomeJournal = game.journal.find(j => j.name === this.welcomeJournal &&
-                      (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId'))
+                      (j._stats?.compendiumSource ?? j.flags?.core?.sourceId)
                         ?.startsWith(`Compendium.${this.moduleName}.`));
                     if (welcomeJournal) {
                       welcomeJournal.sheet.render(true, {sheetMode: 'text'});
@@ -1061,7 +1061,7 @@ export default class ScenePacker {
     if (this.welcomeJournal && foundry.utils.isNewerVersion(moduleVersion, importedVersion)) {
       // Display the welcome journal once per new module version
       const j = game.journal.find(j => j.name === this.welcomeJournal &&
-        (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId'))
+        (j._stats?.compendiumSource ?? j.flags?.core?.sourceId)
           ?.startsWith(`Compendium.${this.moduleName}.`));
       if (j) {
         j.sheet.render(true, {sheetMode: 'text'});
@@ -1727,7 +1727,7 @@ export default class ScenePacker {
     const sceneJournalInfo = {};
     if (scene.journal) {
       sceneJournalInfo.journalName = scene.journal.name;
-      sceneJournalInfo.sourceId = scene.journal.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') || (scene._stats?.compendiumSource ?? scene.journal.getFlag('core', 'sourceId')) || scene.journal.uuid;
+      sceneJournalInfo.sourceId = scene.journal.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') || (scene._stats?.compendiumSource ?? scene.journal.flags?.core?.sourceId) || scene.journal.uuid;
       const compendiumJournal = await this.FindJournalInCompendiums(scene.journal, this.getSearchPacksForType('JournalEntry'));
       if (compendiumJournal?.uuid) {
         sceneJournalInfo.compendiumSourceId = compendiumJournal.uuid;
@@ -1861,7 +1861,7 @@ export default class ScenePacker {
             } else if (actor.data?.name) {
               actorName = actor.data.name;
             }
-            compendiumSourceId = actor._stats?.compendiumSource ?? actor.getFlag('core', 'sourceId');
+            compendiumSourceId = actor._stats?.compendiumSource ?? actor.flags?.core?.sourceId;
             if (!compendiumSourceId || !compendiumSourceId.startsWith(`Compendium.${this.moduleName}.`)) {
               // The actor source isn't the module's compendium, see if we have a direct match in a different compendium
               const compendiumActor = await this.FindActorInCompendiums(actor, this.getSearchPacksForType('Actor'));
@@ -1945,7 +1945,7 @@ export default class ScenePacker {
     }
 
     const sourceId = journal.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
-    const coreSourceId = journal._stats?.compendiumSource ?? journal.getFlag('core', 'sourceId');
+    const coreSourceId = journal._stats?.compendiumSource ?? journal.flags?.core?.sourceId;
 
     let compendiumJournal = null;
     let possibleMatches = [];
@@ -1989,11 +1989,11 @@ export default class ScenePacker {
             return entity;
           }
 
-          if (sourceId && (entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId')) === sourceId) {
+          if (sourceId && (entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId) === sourceId) {
             return entity;
           }
 
-          if (coreSourceId && (entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId')) === coreSourceId) {
+          if (coreSourceId && (entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId) === coreSourceId) {
             return entity;
           }
         }
@@ -2015,7 +2015,7 @@ export default class ScenePacker {
       }
     }
 
-    const compendiumSourceId = journal._stats?.compendiumSource ?? journal.getFlag('core', 'sourceId');
+    const compendiumSourceId = journal._stats?.compendiumSource ?? journal.flags?.core?.sourceId;
     if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
@@ -2180,7 +2180,7 @@ export default class ScenePacker {
       }
     }
 
-    const compendiumSourceId = actor._stats?.compendiumSource ?? actor.getFlag('core', 'sourceId');
+    const compendiumSourceId = actor._stats?.compendiumSource ?? actor.flags?.core?.sourceId;
     if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
@@ -2442,7 +2442,7 @@ export default class ScenePacker {
       }
     }
 
-    const compendiumSourceId = macro._stats?.compendiumSource ?? macro.getFlag('core', 'sourceId');
+    const compendiumSourceId = macro._stats?.compendiumSource ?? macro.flags?.core?.sourceId;
     if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
@@ -2805,7 +2805,7 @@ export default class ScenePacker {
       }
       const matches = game.actors.contents.filter(a => {
         return (
-          a.uuid === token.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === token.sourceId || (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === token.sourceId
+          a.uuid === token.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === token.sourceId || (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === token.sourceId
         ) && !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated');
       });
       if (matches.length) {
@@ -2846,7 +2846,7 @@ export default class ScenePacker {
       }
       const matches = game.journal.contents.filter(a => {
         return (
-          a.uuid === journal.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === journal.sourceId || (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === journal.sourceId || (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === journal.compendiumSourceId
+          a.uuid === journal.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === journal.sourceId || (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === journal.sourceId || (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === journal.compendiumSourceId
         ) && !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated');
       });
       if (matches.length) {
@@ -3013,7 +3013,7 @@ export default class ScenePacker {
     if (actorId) {
       const tData = tokenWorldData.find(t => t.sourceId === `Actor.${actorId}` && t.compendiumSourceId);
       if (tData) {
-        const actor = game.actors.contents.find(a => ((a._stats?.compendiumSource ?? a.getFlag("core", "sourceId")) === tData.compendiumSourceId || a.getFlag(CONSTANTS.MODULE_NAME, "sourceId") === tData.sourceId) && !a.getFlag(CONSTANTS.MODULE_NAME, "deprecated"));
+        const actor = game.actors.contents.find(a => ((a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === tData.compendiumSourceId || a.getFlag(CONSTANTS.MODULE_NAME, "sourceId") === tData.sourceId) && !a.getFlag(CONSTANTS.MODULE_NAME, "deprecated"));
         if (actor) {
           return actor;
         }
@@ -3135,7 +3135,7 @@ export default class ScenePacker {
     return collection.contents.find((a) => {
       return (
         (a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === ref ||
-          (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === ref) &&
+          (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === ref) &&
         !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated')
       );
     });
@@ -3235,7 +3235,7 @@ export default class ScenePacker {
 
     const existingEntity = ScenePacker.FindEntity(entityReference);
     if (existingEntity) {
-      const compendiumSourceId = existingEntity._stats?.compendiumSource ?? existingEntity.getFlag('core', 'sourceId');
+      const compendiumSourceId = existingEntity._stats?.compendiumSource ?? existingEntity.flags?.core?.sourceId;
       if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
         const match = fromUuid(compendiumSourceId);
         if (match) {
@@ -3350,7 +3350,7 @@ export default class ScenePacker {
       const hasUuid = !!note.compendiumSourceId;
       const hasSourceId = !!note.sourceId;
       const existingEntities = game.journal.filter(p => {
-        return (hasUuid && (p._stats?.compendiumSource ?? p.getFlag('core', 'sourceId')) === note.compendiumSourceId) ||
+        return (hasUuid && (p._stats?.compendiumSource ?? p.flags?.core?.sourceId) === note.compendiumSourceId) ||
           (hasSourceId && p.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === note.sourceId);
       });
       if (existingEntities.length) {
@@ -3460,12 +3460,12 @@ export default class ScenePacker {
     }
 
     const hasUuid = !!entity.uuid;
-    const entityCoreSourceId = entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId');
+    const entityCoreSourceId = entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId;
     const entitySourceId = entity.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
     const hasSourceId = !!entitySourceId;
 
     const existingEntities = collection.filter(p => {
-      const coreSourceId = p._stats?.compendiumSource ?? p.getFlag('core', 'sourceId');
+      const coreSourceId = p._stats?.compendiumSource ?? p.flags?.core?.sourceId;
       const sourceId = p.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
 
       if (entity.name !== p.name) {
@@ -3591,7 +3591,7 @@ export default class ScenePacker {
         );
       } else {
         // List all the journals belonging to this module's packs
-        journals = game.journal.filter(j => this.getSearchPacksForType('JournalEntry').some(p => (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId'))
+        journals = game.journal.filter(j => this.getSearchPacksForType('JournalEntry').some(p => (j._stats?.compendiumSource ?? j.flags?.core?.sourceId)
           ?.startsWith(`Compendium.${p}.`)));
       }
       if (journals?.length) {
@@ -3684,7 +3684,7 @@ export default class ScenePacker {
       }
       if (!scene.journal) {
         // Relink the journal to the correct entry
-        let newSceneJournal = game.journal.find(j => j.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId')) === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId')) === sceneJournalInfo.compendiumSourceId);
+        let newSceneJournal = game.journal.find(j => j.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.flags?.core?.sourceId) === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.flags?.core?.sourceId) === sceneJournalInfo.compendiumSourceId);
         if (newSceneJournal?.id) {
           await scene.update({journal: newSceneJournal.id});
         } else if (sceneJournalInfo.compendiumSourceId?.startsWith('Compendium.')) {
@@ -4459,7 +4459,7 @@ export default class ScenePacker {
             // Only support unpacking Compendium references
             continue;
           }
-          const match = game.actors.contents.find(a => (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === actor.actorID);
+          const match = game.actors.contents.find(a => (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === actor.actorID);
           if (match) {
             updates.push({
               type: 'Actor',
@@ -4630,7 +4630,7 @@ export default class ScenePacker {
       }
     }
 
-    const sourceId = entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId');
+    const sourceId = entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId;
     if (!sourceId) {
       return;
     }

--- a/scripts/welcome-journal.js
+++ b/scripts/welcome-journal.js
@@ -69,42 +69,42 @@ export default class WelcomeJournal extends JournalSheet {
         instance.importAllContent();
       } else if (e.target.classList.contains('sp-import-replace')) {
         const deleteExisting = async function () {
-          const sceneIDs = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const sceneIDs = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (sceneIDs.length) {
             await Scene.deleteDocuments(sceneIDs);
           }
-          const actorIDs = game.actors.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const actorIDs = game.actors.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (actorIDs.length) {
             await Actor.deleteDocuments(actorIDs);
           }
-          const itemIDs = game.items.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const itemIDs = game.items.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (itemIDs.length) {
             await Item.deleteDocuments(itemIDs);
           }
-          const journalIDs = game.journal.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const journalIDs = game.journal.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (journalIDs.length) {
             await JournalEntry.deleteDocuments(journalIDs);
           }
-          const rollTableIDs = game.tables.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const rollTableIDs = game.tables.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (rollTableIDs.length) {
             await RollTable.deleteDocuments(rollTableIDs);
           }
-          const playlistIDs = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const playlistIDs = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (playlistIDs.length) {
             await Playlist.deleteDocuments(playlistIDs);
           }
-          const macroIDs = game.macros.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const macroIDs = game.macros.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (macroIDs.length) {
             await Macro.deleteDocuments(macroIDs);
           }
-          const cardIDs = game.cards.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const cardIDs = game.cards.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`)).map(s => s.id);
           if (cardIDs.length) {
             await Card.deleteDocuments(cardIDs);

--- a/styles/scene-packer.css
+++ b/styles/scene-packer.css
@@ -274,3 +274,42 @@
 #scene-packer-exporter .tabs.sheet-tabs [data-tab] {
   padding: 0;
 }
+#scene-packer-exporter .template-management {
+  margin-top: 1em;
+}
+#scene-packer-exporter .template-management .form-fields {
+  display: flex;
+  gap: 10px;
+  margin-top: 0.5em;
+}
+#scene-packer-exporter .template-management button {
+  flex: 1;
+  padding: 8px 12px;
+}
+.missing-documents-warning {
+  padding: 10px;
+}
+.missing-documents-warning .warning-message {
+  color: #ff6400;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+.missing-documents-warning .missing-list {
+  max-height: 300px;
+  overflow-y: auto;
+  margin: 10px 0;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+}
+.missing-documents-warning .missing-item {
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+.missing-documents-warning .missing-item:last-child {
+  border-bottom: none;
+}
+.missing-documents-warning .continue-message {
+  margin-top: 10px;
+  font-style: italic;
+}

--- a/templates/export-import/exporter.hbs
+++ b/templates/export-import/exporter.hbs
@@ -509,6 +509,22 @@
       </div>
 
       <hr>
+      <div class="form-group template-management">
+        <label>
+          <b>{{localize "SCENE-PACKER.exporter.template.label"}}</b>
+          <i class="fas fa-question-circle" title="{{localize 'SCENE-PACKER.exporter.template.help'}}"></i>
+        </label>
+        <div class="form-fields">
+          <button type="button" class="save-template">
+            <i class="fas fa-save"></i> {{localize "SCENE-PACKER.exporter.template.save"}}
+          </button>
+          <button type="button" class="load-template">
+            <i class="fas fa-upload"></i> {{localize "SCENE-PACKER.exporter.template.load"}}
+          </button>
+        </div>
+      </div>
+
+      <hr>
       <p>{{{localize 'SCENE-PACKER.exporter.options.next'}}}</p>
       <p>{{{localize 'SCENE-PACKER.exporter.options.help'}}}</p>
       <hr>

--- a/templates/export-import/template-missing-documents.hbs
+++ b/templates/export-import/template-missing-documents.hbs
@@ -1,0 +1,18 @@
+<div class="missing-documents-warning">
+  <p class="warning-message">
+    <i class="fas fa-exclamation-triangle"></i>
+    {{localize "SCENE-PACKER.exporter.template.missing-warning"}}
+  </p>
+  
+  <div class="missing-list">
+    {{#each missingItems}}
+      <div class="missing-item">
+        <strong>{{type}}:</strong> {{name}} <em>(ID: {{id}})</em>
+      </div>
+    {{/each}}
+  </div>
+  
+  <p class="continue-message">
+    {{localize "SCENE-PACKER.exporter.template.missing-continue"}}
+  </p>
+</div>


### PR DESCRIPTION
- Added Export Template feature to Moulinette exporter.
  - Users can now save their selections and form configuration as a downloadable JSON template file.
  - Templates can be loaded later to restore selections and settings.
  - Warning dialog displays when loading templates with documents that no longer exist.
- Fixed the Moulinette importer sometimes getting stuck on the "Loading data..." spinner the first time a pack was opened, requiring the window to be closed and reopened.
  - Thank you [BeneosBattlemaps](https://github.com/BeneosBattlemaps) for the contribution.
- Fixed importing on dnd5e 5.x / Foundry V13 flooding the console with "Failed data preparation" errors by creating imported documents via the system's document class.
  - Thank you [BeneosBattlemaps](https://github.com/BeneosBattlemaps) for the contribution.
- Reduced deprecation warnings logged while importing by reading the legacy `core.sourceId` flag directly instead of via the deprecated getter.