### PR TITLE
V13 / dnd5e v5 import & template fixes

### DIFF
--- a/scripts/export-import/exporter.js
+++ b/scripts/export-import/exporter.js
@@ -559,6 +559,24 @@ export default class Exporter extends FormApplication {
       });
     });
 
+    // Capture individually-selected playlist sounds. PlaylistSound is an
+    // embedded document (no top-level collection), so resolve its name by
+    // looking it up inside the playlists. This lets a saved template carry the
+    // exact sounds a package uses, so the playlist is trimmed on export.
+    selections.PlaylistSound = [];
+    this.element.find('input[data-type="PlaylistSound"]:checked').each((i, el) => {
+      const id = el.value;
+      let name = id;
+      for (const playlist of game.playlists) {
+        const sound = playlist.sounds.get(id);
+        if (sound) {
+          name = sound.name;
+          break;
+        }
+      }
+      selections.PlaylistSound.push({ id, name });
+    });
+
     return {
       name: formData.packageName,
       author: formData.author,
@@ -769,6 +787,16 @@ export default class Exporter extends FormApplication {
           });
         }
       });
+
+      // Restore individually-selected playlist sounds. PlaylistSound is an
+      // embedded document with no top-level CONFIG collection, so it is handled
+      // separately from the documentTypes loop above: just tick the matching
+      // sound checkbox if it exists in the rendered playlist tree.
+      if (Array.isArray(template.selections.PlaylistSound)) {
+        template.selections.PlaylistSound.forEach(item => {
+          this.element.find(`input[data-type="PlaylistSound"][value="${item.id}"]`).prop('checked', true);
+        });
+      }
     }
 
     let scenePackerExporter = $('#scene-packer-exporter');

--- a/scripts/export-import/zip-importer.js
+++ b/scripts/export-import/zip-importer.js
@@ -319,11 +319,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await Scene.createDocuments(await Promise.all(documents.map(async d => Scene.fromImport({...d, active: false}))), { keepId: true });
+        created = await getDocumentClass("Scene").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Scene").fromImport({...d, active: false}))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await Scene.createDocuments(documents.map(d => Scene.fromSource({...d, active: false}).toObject()), { keepId: true });
+        created = await getDocumentClass("Scene").createDocuments(documents.map(d => getDocumentClass("Scene").fromSource({...d, active: false}).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the scenes and update them to local world references
@@ -373,11 +373,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await Actor.createDocuments(await Promise.all(documents.map(async d => Actor.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("Actor").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Actor").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await Actor.createDocuments(documents.map(d => Actor.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("Actor").createDocuments(documents.map(d => getDocumentClass("Actor").fromSource(d).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the actors and update them to local world references
@@ -443,11 +443,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await JournalEntry.createDocuments(await Promise.all(documents.map(async d => JournalEntry.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("JournalEntry").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("JournalEntry").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await JournalEntry.createDocuments(documents.map(d => JournalEntry.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("JournalEntry").createDocuments(documents.map(d => getDocumentClass("JournalEntry").fromSource(d).toObject()), { keepId: true });
       }
       if (this.scenePackerInfo?.welcome_journal) {
         if (created.find(j => j.id === this.scenePackerInfo.welcome_journal)) {
@@ -491,11 +491,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        created = await Item.createDocuments(await Promise.all(documents.map(async d => Item.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("Item").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Item").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await Item.createDocuments(documents.map(d => Item.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("Item").createDocuments(documents.map(d => getDocumentClass("Item").fromSource(d).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the items and update them to local world references
@@ -533,11 +533,11 @@ export default class ZipImporter extends FormApplication {
       }
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions since v12.
-        await Macro.createDocuments(await Promise.all(documents.map(async d => Macro.fromImport(d))), { keepId: true });
+        await getDocumentClass("Macro").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Macro").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        await Macro.createDocuments(documents.map(d => Macro.fromSource(d).toObject()), { keepId: true });
+        await getDocumentClass("Macro").createDocuments(documents.map(d => getDocumentClass("Macro").fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -571,7 +571,7 @@ export default class ZipImporter extends FormApplication {
         }
         const playlistData = existingPlaylist.toJSON();
         const sounds = playlistData.sounds || [];
-        const newPlaylistData = Playlist.fromSource(d).toObject();
+        const newPlaylistData = getDocumentClass("Playlist").fromSource(d).toObject();
         const newSounds = [];
         let hasUpdates = false;
         for (const sound of (newPlaylistData.sounds || [])) {
@@ -596,11 +596,11 @@ export default class ZipImporter extends FormApplication {
       if (documents.length) {
         if (CONSTANTS.IsV12orNewer()) {
           // Run via the .fromImport method as that migrates data from old game versions.
-          await Playlist.createDocuments(await Promise.all(documents.map(async d => Playlist.fromImport(d))), { keepId: true });
+          await getDocumentClass("Playlist").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Playlist").fromImport(d))), { keepId: true });
         } else {
           // Run via the .fromSource method as that operates in a non-strict validation format, allowing
           // for older formats to still be parsed in most cases.
-          await Playlist.createDocuments(documents.map(d => Playlist.fromSource(d).toObject()), { keepId: true });
+          await getDocumentClass("Playlist").createDocuments(documents.map(d => getDocumentClass("Playlist").fromSource(d).toObject()), { keepId: true });
         }
       }
     }
@@ -628,11 +628,11 @@ export default class ZipImporter extends FormApplication {
       }
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions.
-        await Cards.createDocuments(await Promise.all(documents.map(async d => Cards.fromImport(d))), { keepId: true });
+        await getDocumentClass("Cards").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("Cards").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        await Cards.createDocuments(documents.map(d => Cards.fromSource(d).toObject()), { keepId: true });
+        await getDocumentClass("Cards").createDocuments(documents.map(d => getDocumentClass("Cards").fromSource(d).toObject()), { keepId: true });
       }
     }
 
@@ -660,11 +660,11 @@ export default class ZipImporter extends FormApplication {
       let created = [];
       if (CONSTANTS.IsV12orNewer()) {
         // Run via the .fromImport method as that migrates data from old game versions.
-        created = await RollTable.createDocuments(await Promise.all(documents.map(async d => RollTable.fromImport(d))), { keepId: true });
+        created = await getDocumentClass("RollTable").createDocuments(await Promise.all(documents.map(async d => getDocumentClass("RollTable").fromImport(d))), { keepId: true });
       } else {
         // Run via the .fromSource method as that operates in a non-strict validation format, allowing
         // for older formats to still be parsed in most cases.
-        created = await RollTable.createDocuments(documents.map(d => RollTable.fromSource(d).toObject()), { keepId: true });
+        created = await getDocumentClass("RollTable").createDocuments(documents.map(d => getDocumentClass("RollTable").fromSource(d).toObject()), { keepId: true });
       }
 
       // Check for compendium references within the roll tables and update them to local world references

--- a/scripts/scene-packer.js
+++ b/scripts/scene-packer.js
@@ -229,21 +229,21 @@ export default class ScenePacker {
           // The yes callback during an upgrade of a module removes all existing entries that came from this module before
           // importing everything in again.
           // Folders are untouched.
-          const scenes = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const scenes = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const actors = game.actors.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const actors = game.actors.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const items = game.items.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const items = game.items.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const journals = game.journal.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const journals = game.journal.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const rollTables = game.tables.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const rollTables = game.tables.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const playlists = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const playlists = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const macros = game.macros.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const macros = game.macros.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
-          const cards = game.cards.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+          const cards = game.cards.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
             ?.startsWith(`Compendium.${this.moduleName}`));
 
           let listToDelete = '';
@@ -276,49 +276,49 @@ export default class ScenePacker {
           }
 
           const doReplacement = async function () {
-            const sceneIDs = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const sceneIDs = game.scenes.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (sceneIDs.length) {
               await Scene.deleteDocuments(sceneIDs);
             }
-            const actorIDs = game.actors.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const actorIDs = game.actors.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (actorIDs.length) {
               await Actor.deleteDocuments(actorIDs);
             }
-            const itemIDs = game.items.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const itemIDs = game.items.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (itemIDs.length) {
               await Item.deleteDocuments(itemIDs);
             }
-            const journalIDs = game.journal.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const journalIDs = game.journal.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (journalIDs.length) {
               await JournalEntry.deleteDocuments(journalIDs);
             }
-            const rollTableIDs = game.tables.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const rollTableIDs = game.tables.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (rollTableIDs.length) {
               await RollTable.deleteDocuments(rollTableIDs);
             }
-            const playlistIDs = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const playlistIDs = game.playlists.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (playlistIDs.length) {
               await Playlist.deleteDocuments(playlistIDs);
             }
-            const macroIDs = game.macros.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const macroIDs = game.macros.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (macroIDs.length) {
               await Macro.deleteDocuments(macroIDs);
             }
-            const cardIDs = game.cards.filter(s => (s._stats?.compendiumSource ?? s.getFlag('core', 'sourceId'))
+            const cardIDs = game.cards.filter(s => (s._stats?.compendiumSource ?? s.flags?.core?.sourceId)
               ?.startsWith(`Compendium.${this.moduleName}`))
               .map(s => s.id);
             if (cardIDs.length) {
@@ -466,10 +466,10 @@ export default class ScenePacker {
               return true;
             }
             let sourceId = e._stats?.compendiumSource ?? e.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
-            let coreSourceId = e._stats?.compendiumSource ?? e.getFlag('core', 'sourceId');
+            let coreSourceId = e._stats?.compendiumSource ?? e.flags?.core?.sourceId;
             const hasExistingEntryWithID = collection.get(e.id);
             if (hasExistingEntryWithID || sourceId || coreSourceId) {
-              const existingEntries = collection.filter(f => f.id === e.id || (sourceId && f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sourceId) || (coreSourceId && (f._stats?.compendiumSource ?? f.getFlag('core', 'sourceId')) === coreSourceId));
+              const existingEntries = collection.filter(f => f.id === e.id || (sourceId && f.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sourceId) || (coreSourceId && (f._stats?.compendiumSource ?? f.flags?.core?.sourceId) === coreSourceId));
               if (existingEntries.length && forceImport && renameOriginals) {
                 // Update the existing entry names
                 const newFlags = {};
@@ -619,7 +619,7 @@ export default class ScenePacker {
                   // so the current version flag won't have been set yet.
                   if (foundry.utils.isNewerVersion(moduleVersion, importedVersion)) {
                     let welcomeJournal = game.journal.find(j => j.name === this.welcomeJournal &&
-                      (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId'))
+                      (j._stats?.compendiumSource ?? j.flags?.core?.sourceId)
                         ?.startsWith(`Compendium.${this.moduleName}.`));
                     if (welcomeJournal) {
                       welcomeJournal.sheet.render(true, {sheetMode: 'text'});
@@ -1061,7 +1061,7 @@ export default class ScenePacker {
     if (this.welcomeJournal && foundry.utils.isNewerVersion(moduleVersion, importedVersion)) {
       // Display the welcome journal once per new module version
       const j = game.journal.find(j => j.name === this.welcomeJournal &&
-        (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId'))
+        (j._stats?.compendiumSource ?? j.flags?.core?.sourceId)
           ?.startsWith(`Compendium.${this.moduleName}.`));
       if (j) {
         j.sheet.render(true, {sheetMode: 'text'});
@@ -1727,7 +1727,7 @@ export default class ScenePacker {
     const sceneJournalInfo = {};
     if (scene.journal) {
       sceneJournalInfo.journalName = scene.journal.name;
-      sceneJournalInfo.sourceId = scene.journal.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') || (scene._stats?.compendiumSource ?? scene.journal.getFlag('core', 'sourceId')) || scene.journal.uuid;
+      sceneJournalInfo.sourceId = scene.journal.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') || (scene._stats?.compendiumSource ?? scene.journal.flags?.core?.sourceId) || scene.journal.uuid;
       const compendiumJournal = await this.FindJournalInCompendiums(scene.journal, this.getSearchPacksForType('JournalEntry'));
       if (compendiumJournal?.uuid) {
         sceneJournalInfo.compendiumSourceId = compendiumJournal.uuid;
@@ -1861,7 +1861,7 @@ export default class ScenePacker {
             } else if (actor.data?.name) {
               actorName = actor.data.name;
             }
-            compendiumSourceId = actor._stats?.compendiumSource ?? actor.getFlag('core', 'sourceId');
+            compendiumSourceId = actor._stats?.compendiumSource ?? actor.flags?.core?.sourceId;
             if (!compendiumSourceId || !compendiumSourceId.startsWith(`Compendium.${this.moduleName}.`)) {
               // The actor source isn't the module's compendium, see if we have a direct match in a different compendium
               const compendiumActor = await this.FindActorInCompendiums(actor, this.getSearchPacksForType('Actor'));
@@ -1945,7 +1945,7 @@ export default class ScenePacker {
     }
 
     const sourceId = journal.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
-    const coreSourceId = journal._stats?.compendiumSource ?? journal.getFlag('core', 'sourceId');
+    const coreSourceId = journal._stats?.compendiumSource ?? journal.flags?.core?.sourceId;
 
     let compendiumJournal = null;
     let possibleMatches = [];
@@ -1989,11 +1989,11 @@ export default class ScenePacker {
             return entity;
           }
 
-          if (sourceId && (entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId')) === sourceId) {
+          if (sourceId && (entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId) === sourceId) {
             return entity;
           }
 
-          if (coreSourceId && (entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId')) === coreSourceId) {
+          if (coreSourceId && (entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId) === coreSourceId) {
             return entity;
           }
         }
@@ -2015,7 +2015,7 @@ export default class ScenePacker {
       }
     }
 
-    const compendiumSourceId = journal._stats?.compendiumSource ?? journal.getFlag('core', 'sourceId');
+    const compendiumSourceId = journal._stats?.compendiumSource ?? journal.flags?.core?.sourceId;
     if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
@@ -2180,7 +2180,7 @@ export default class ScenePacker {
       }
     }
 
-    const compendiumSourceId = actor._stats?.compendiumSource ?? actor.getFlag('core', 'sourceId');
+    const compendiumSourceId = actor._stats?.compendiumSource ?? actor.flags?.core?.sourceId;
     if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
@@ -2442,7 +2442,7 @@ export default class ScenePacker {
       }
     }
 
-    const compendiumSourceId = macro._stats?.compendiumSource ?? macro.getFlag('core', 'sourceId');
+    const compendiumSourceId = macro._stats?.compendiumSource ?? macro.flags?.core?.sourceId;
     if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
       const match = fromUuid(compendiumSourceId);
       if (match) {
@@ -2805,7 +2805,7 @@ export default class ScenePacker {
       }
       const matches = game.actors.contents.filter(a => {
         return (
-          a.uuid === token.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === token.sourceId || (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === token.sourceId
+          a.uuid === token.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === token.sourceId || (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === token.sourceId
         ) && !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated');
       });
       if (matches.length) {
@@ -2846,7 +2846,7 @@ export default class ScenePacker {
       }
       const matches = game.journal.contents.filter(a => {
         return (
-          a.uuid === journal.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === journal.sourceId || (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === journal.sourceId || (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === journal.compendiumSourceId
+          a.uuid === journal.sourceId || a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === journal.sourceId || (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === journal.sourceId || (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === journal.compendiumSourceId
         ) && !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated');
       });
       if (matches.length) {
@@ -3013,7 +3013,7 @@ export default class ScenePacker {
     if (actorId) {
       const tData = tokenWorldData.find(t => t.sourceId === `Actor.${actorId}` && t.compendiumSourceId);
       if (tData) {
-        const actor = game.actors.contents.find(a => ((a._stats?.compendiumSource ?? a.getFlag("core", "sourceId")) === tData.compendiumSourceId || a.getFlag(CONSTANTS.MODULE_NAME, "sourceId") === tData.sourceId) && !a.getFlag(CONSTANTS.MODULE_NAME, "deprecated"));
+        const actor = game.actors.contents.find(a => ((a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === tData.compendiumSourceId || a.getFlag(CONSTANTS.MODULE_NAME, "sourceId") === tData.sourceId) && !a.getFlag(CONSTANTS.MODULE_NAME, "deprecated"));
         if (actor) {
           return actor;
         }
@@ -3135,7 +3135,7 @@ export default class ScenePacker {
     return collection.contents.find((a) => {
       return (
         (a.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === ref ||
-          (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === ref) &&
+          (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === ref) &&
         !a.getFlag(CONSTANTS.MODULE_NAME, 'deprecated')
       );
     });
@@ -3235,7 +3235,7 @@ export default class ScenePacker {
 
     const existingEntity = ScenePacker.FindEntity(entityReference);
     if (existingEntity) {
-      const compendiumSourceId = existingEntity._stats?.compendiumSource ?? existingEntity.getFlag('core', 'sourceId');
+      const compendiumSourceId = existingEntity._stats?.compendiumSource ?? existingEntity.flags?.core?.sourceId;
       if (compendiumSourceId && searchPacks.some(p => compendiumSourceId.startsWith(`Compendium.${p}.`))) {
         const match = fromUuid(compendiumSourceId);
         if (match) {
@@ -3350,7 +3350,7 @@ export default class ScenePacker {
       const hasUuid = !!note.compendiumSourceId;
       const hasSourceId = !!note.sourceId;
       const existingEntities = game.journal.filter(p => {
-        return (hasUuid && (p._stats?.compendiumSource ?? p.getFlag('core', 'sourceId')) === note.compendiumSourceId) ||
+        return (hasUuid && (p._stats?.compendiumSource ?? p.flags?.core?.sourceId) === note.compendiumSourceId) ||
           (hasSourceId && p.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === note.sourceId);
       });
       if (existingEntities.length) {
@@ -3460,12 +3460,12 @@ export default class ScenePacker {
     }
 
     const hasUuid = !!entity.uuid;
-    const entityCoreSourceId = entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId');
+    const entityCoreSourceId = entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId;
     const entitySourceId = entity.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
     const hasSourceId = !!entitySourceId;
 
     const existingEntities = collection.filter(p => {
-      const coreSourceId = p._stats?.compendiumSource ?? p.getFlag('core', 'sourceId');
+      const coreSourceId = p._stats?.compendiumSource ?? p.flags?.core?.sourceId;
       const sourceId = p.getFlag(CONSTANTS.MODULE_NAME, 'sourceId');
 
       if (entity.name !== p.name) {
@@ -3591,7 +3591,7 @@ export default class ScenePacker {
         );
       } else {
         // List all the journals belonging to this module's packs
-        journals = game.journal.filter(j => this.getSearchPacksForType('JournalEntry').some(p => (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId'))
+        journals = game.journal.filter(j => this.getSearchPacksForType('JournalEntry').some(p => (j._stats?.compendiumSource ?? j.flags?.core?.sourceId)
           ?.startsWith(`Compendium.${p}.`)));
       }
       if (journals?.length) {
@@ -3684,7 +3684,7 @@ export default class ScenePacker {
       }
       if (!scene.journal) {
         // Relink the journal to the correct entry
-        let newSceneJournal = game.journal.find(j => j.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId')) === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.getFlag('core', 'sourceId')) === sceneJournalInfo.compendiumSourceId);
+        let newSceneJournal = game.journal.find(j => j.getFlag(CONSTANTS.MODULE_NAME, 'sourceId') === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.flags?.core?.sourceId) === sceneJournalInfo.sourceId || (j._stats?.compendiumSource ?? j.flags?.core?.sourceId) === sceneJournalInfo.compendiumSourceId);
         if (newSceneJournal?.id) {
           await scene.update({journal: newSceneJournal.id});
         } else if (sceneJournalInfo.compendiumSourceId?.startsWith('Compendium.')) {
@@ -4459,7 +4459,7 @@ export default class ScenePacker {
             // Only support unpacking Compendium references
             continue;
           }
-          const match = game.actors.contents.find(a => (a._stats?.compendiumSource ?? a.getFlag('core', 'sourceId')) === actor.actorID);
+          const match = game.actors.contents.find(a => (a._stats?.compendiumSource ?? a.flags?.core?.sourceId) === actor.actorID);
           if (match) {
             updates.push({
               type: 'Actor',
@@ -4630,7 +4630,7 @@ export default class ScenePacker {
       }
     }
 
-    const sourceId = entity._stats?.compendiumSource ?? entity.getFlag('core', 'sourceId');
+    const sourceId = entity._stats?.compendiumSource ?? entity.flags?.core?.sourceId;
     if (!sourceId) {
       return;
     }


### PR DESCRIPTION
Three small fixes found while batch-importing adventures on **dnd5e 5.x / Foundry V13** (scene-packer 2.8.12). Each is an isolated commit so they can be taken independently.

### 1. Persist `PlaylistSound` selections in export templates
The exporter template does not round-trip per-sound selections, so loading a template that selected a playlist exports it with **zero** sounds (since `ExporterProgress` trims a playlist down to the explicitly selected sounds). `_collectFormData` now captures the checked `PlaylistSound` inputs and `_applyTemplate` restores them.

### 2. Create imported documents via the system document class
`zip-importer` built imported documents with the global base classes (`Actor`, `Item`, `Scene`, ...) instead of `getDocumentClass(type)`. On dnd5e 5.x, `prepareDerivedData` then calls Actor5e-only methods (e.g. `getOriginalStats`) on a base `Actor`, throwing a caught "Failed data preparation" error for **every actor** during import (a console flood that can stall hosted instances). Switched the per-type blocks to `getDocumentClass(type)`, matching the generic-type block already present later in the same file.

### 3. Avoid the deprecated `core.sourceId` getter
The `_stats.compendiumSource ?? x.getFlag('core', 'sourceId')` fallback calls the deprecated getter, which logs a V12 deprecation warning on every access -- even for documents that have no such flag -- firing once per scene during import (plus other reference paths). Reads `flags.core.sourceId` directly as the fallback instead: equivalent, without the warning.

Targeted the `2.8.12` branch because #1 touches the template feature that lives there; #2 and #3 also apply cleanly to `main` if you'd prefer them ported.