### PR TITLE
Fix Moulinette importer stuck on loading spinner on first open

### DIFF
--- a/scripts/export-import/moulinette-importer.js
+++ b/scripts/export-import/moulinette-importer.js
@@ -48,6 +48,7 @@ export default class MoulinetteImporter extends FormApplication {
     this.processingMessage = '';
     this.errorMessage = '';
     this.loading = true;
+    this.pendingRender = false;
 
     if (!this.packInfo || !this.packInfo['mtte.json']) {
       ScenePacker.logType(
@@ -57,7 +58,7 @@ export default class MoulinetteImporter extends FormApplication {
         game.i18n.localize('SCENE-PACKER.importer.invalid-pack-data'),
       );
       this.errorMessage = game.i18n.localize('SCENE-PACKER.importer.invalid-pack-data');
-      this.render();
+      this.render(true);
 
       return;
     }
@@ -72,8 +73,48 @@ export default class MoulinetteImporter extends FormApplication {
 
         return;
       }
-      this.render();
+      this.requestRender();
+    }).catch(err => {
+      this.loading = true;
+      this.errorMessage = game.i18n.localize('SCENE-PACKER.importer.invalid-pack-data');
+      ScenePacker.logType(
+        game.i18n.localize('SCENE-PACKER.importer.name'),
+        'error',
+        true,
+        err?.message ?? String(err),
+      );
+      this.requestRender();
     });
+  }
+
+  /**
+   * Render the importer once the package metadata has loaded.
+   *
+   * The importer is opened externally by Moulinette via `render(true)`, which
+   * begins an asynchronous render. The metadata fetch frequently resolves while
+   * that initial render is still in progress. `Application._render` ignores any
+   * render requested while the Application is in the RENDERING state (even a
+   * forced one), so a render triggered here would be silently dropped and the
+   * window would stay stuck on the loading spinner with the import buttons
+   * disabled until it was closed and reopened. To avoid that race the render is
+   * deferred until the in-progress render finishes (flushed in `_render`).
+   */
+  requestRender() {
+    if (this._state === this.constructor.RENDER_STATES.RENDERING) {
+      this.pendingRender = true;
+
+      return;
+    }
+    this.render(true);
+  }
+
+  /** @inheritdoc */
+  async _render(force, options) {
+    await super._render(force, options);
+    if (this.pendingRender) {
+      this.pendingRender = false;
+      await super._render(true, options);
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem
When opening a Scene Packer pack from the Moulinette browser (pick a creator, then a pack, then click a map), the "Scene Packer: Importer" window opens but is stuck on an infinite "Loading data..." spinner with the import buttons disabled. There is no error message. Closing the window and reopening it shows the pack content immediately and works fine, which makes the issue look intermittent.

## Cause
Moulinette opens the importer externally via `new MoulinetteImporter(...).render(true)`, which begins an asynchronous render. The constructor's `mtte.json` metadata fetch frequently resolves *while* that initial render is still in progress. `Application._render` returns early for any render requested while the application is in the `RENDERING` state, even a forced one:

```js
if ( [states.CLOSING, states.RENDERING].includes(this._state) ) return;
```

So the `render()` in the fetch callback (which clears `loading`) is silently dropped, the initial render completes showing the spinner, and the window stays stuck. On reopen the fetch is served from cache and resolves before the render starts, so it renders the content correctly.

## Fix
Defer the post-load render until the in-progress render has finished:

- `requestRender()` renders immediately when the app is idle, or sets a `pendingRender` flag if a render is currently in progress.
- An `_render` override flushes `pendingRender` once the current render completes.
- A `catch` is added so a failed metadata fetch shows the error message instead of hanging on the spinner.

## Testing
Verified in Foundry VTT V13 (13.351) with Scene Packer 2.8.12 and the Moulinette module, importing Beneos Battlemaps Scene Packer packs. The importer was instrumented to confirm both timings:

- fetch resolves during the initial render (`RENDERING`): handled via the deferred `pendingRender` flush.
- fetch resolves after the initial render (`RENDERED`): handled via the immediate render.

In both cases the window now shows the pack content with enabled import buttons on the first open, with no need to close and reopen.
